### PR TITLE
A few hotkeys for switching between gizmo operations

### DIFF
--- a/Brio/Config/InputConfiguration.cs
+++ b/Brio/Config/InputConfiguration.cs
@@ -20,6 +20,9 @@ internal class InputConfiguration
         { KeyBindEvents.Posing_DisableGizmo, new(VirtualKey.SHIFT) },
         { KeyBindEvents.Posing_DisableSkeleton, new(VirtualKey.CONTROL) },
         { KeyBindEvents.Posing_HideOverlay, new(VirtualKey.MENU) },
+        { KeyBindEvents.Posing_Translate, new(VirtualKey.NO_KEY) },
+        { KeyBindEvents.Posing_Rotate, new(VirtualKey.NO_KEY) },
+        { KeyBindEvents.Posing_Scale, new(VirtualKey.NO_KEY) },
     };
 
     public bool ShowPromptsInGPose { get; set; } = true;

--- a/Brio/Game/Posing/PosingService.cs
+++ b/Brio/Game/Posing/PosingService.cs
@@ -5,7 +5,7 @@ namespace Brio.Game.Posing;
 
 internal class PosingService
 {
-    public PosingOperation Operation { get; set; } = PosingOperation.Translate;
+    public PosingOperation Operation { get; set; } = PosingOperation.Rotate;
     
     public PosingCoordinateMode CoordinateMode { get; set; } = PosingCoordinateMode.Local;
 
@@ -50,6 +50,6 @@ internal static class PosingExtensions
         PosingOperation.Translate => OPERATION.TRANSLATE,
         PosingOperation.Rotate => OPERATION.ROTATE,
         PosingOperation.Scale => OPERATION.SCALE,
-        _ => OPERATION.TRANSLATE
+        _ => OPERATION.ROTATE
     };
 }

--- a/Brio/Game/Posing/PosingService.cs
+++ b/Brio/Game/Posing/PosingService.cs
@@ -5,6 +5,8 @@ namespace Brio.Game.Posing;
 
 internal class PosingService
 {
+    public PosingOperation Operation { get; set; } = PosingOperation.Translate;
+    
     public PosingCoordinateMode CoordinateMode { get; set; } = PosingCoordinateMode.Local;
 
     public BoneCategories BoneCategories { get; } = new();
@@ -28,6 +30,12 @@ internal enum PosingCoordinateMode
     World
 }
 
+internal enum PosingOperation {
+    Translate,
+    Rotate,
+    Scale
+}
+
 internal static class PosingExtensions
 {
     public static MODE AsGizmoMode(this PosingCoordinateMode mode) => mode switch
@@ -35,5 +43,13 @@ internal static class PosingExtensions
         PosingCoordinateMode.Local => MODE.LOCAL,
         PosingCoordinateMode.World => MODE.WORLD,
         _ => MODE.LOCAL
+    };
+
+    public static OPERATION AsGizmoOperation(this PosingOperation operation) => operation switch 
+    {
+        PosingOperation.Translate => OPERATION.TRANSLATE,
+        PosingOperation.Rotate => OPERATION.ROTATE,
+        PosingOperation.Scale => OPERATION.SCALE,
+        _ => OPERATION.TRANSLATE
     };
 }

--- a/Brio/Input/KeyBindEvents.cs
+++ b/Brio/Input/KeyBindEvents.cs
@@ -13,4 +13,7 @@ internal enum KeyBindEvents
     Posing_ToggleOverlay,
     Posing_Undo,
     Posing_Redo,
+    Posing_Translate,
+    Posing_Rotate,
+    Posing_Scale
 }

--- a/Brio/Resources/Embedded/Language/en.json
+++ b/Brio/Resources/Embedded/Language/en.json
@@ -228,6 +228,9 @@
     "Posing_HideOverlay": "Hide Overlay",
     "Posing_ToggleOverlay": "Toggle Overlay",
     "Posing_Undo": "Undo",
-    "Posing_Redo": "Redo"
+    "Posing_Redo": "Redo",
+    "Posing_Translate": "Position",
+    "Posing_Rotate": "Rotation",
+    "Posing_Scale": "Scale"
   }
 }

--- a/Brio/UI/Windows/SettingsWindow.cs
+++ b/Brio/UI/Windows/SettingsWindow.cs
@@ -527,6 +527,9 @@ internal class SettingsWindow : Window
                 DrawKeyBind(KeyBindEvents.Posing_ToggleOverlay);
                 DrawKeyBind(KeyBindEvents.Posing_Undo);
                 DrawKeyBind(KeyBindEvents.Posing_Redo);
+                DrawKeyBind(KeyBindEvents.Posing_Translate);
+                DrawKeyBind(KeyBindEvents.Posing_Rotate);
+                DrawKeyBind(KeyBindEvents.Posing_Scale);
             }
         }
     }

--- a/Brio/UI/Windows/Specialized/PosingOverlayToolbarWindow.cs
+++ b/Brio/UI/Windows/Specialized/PosingOverlayToolbarWindow.cs
@@ -2,6 +2,7 @@
 using Brio.Config;
 using Brio.Entities;
 using Brio.Game.Posing;
+using Brio.Input;
 using Brio.UI.Controls.Core;
 using Brio.UI.Controls.Editors;
 using Brio.UI.Controls.Stateless;
@@ -140,12 +141,12 @@ internal class PosingOverlayToolbarWindow : Window
 
         ImGui.Separator();
 
-        using(ImRaii.PushColor(ImGuiCol.Text, _overlayWindow.Operation == OPERATION.TRANSLATE ? UIConstants.ToggleButtonActive : UIConstants.ToggleButtonInactive))
+        using(ImRaii.PushColor(ImGuiCol.Text, _posingService.Operation == PosingOperation.Translate ? UIConstants.ToggleButtonActive : UIConstants.ToggleButtonInactive))
         {
             using(ImRaii.PushFont(UiBuilder.IconFont))
             {
-                if(ImGui.Button($"{FontAwesomeIcon.ArrowsUpDownLeftRight.ToIconString()}###select_position", new Vector2(buttonSize)))
-                    _overlayWindow.Operation = OPERATION.TRANSLATE;
+                if(ImGui.Button($"{FontAwesomeIcon.ArrowsUpDownLeftRight.ToIconString()}###select_position", new Vector2(buttonSize)) || InputService.IsKeyBindDown(KeyBindEvents.Posing_Translate))
+                    _posingService.Operation = PosingOperation.Translate;
             }
         }
         if(ImGui.IsItemHovered())
@@ -154,12 +155,12 @@ internal class PosingOverlayToolbarWindow : Window
         ImGui.SameLine();
 
 
-        using(ImRaii.PushColor(ImGuiCol.Text, _overlayWindow.Operation == OPERATION.ROTATE ? UIConstants.ToggleButtonActive : UIConstants.ToggleButtonInactive))
+        using(ImRaii.PushColor(ImGuiCol.Text, _posingService.Operation == PosingOperation.Rotate ? UIConstants.ToggleButtonActive : UIConstants.ToggleButtonInactive))
         {
             using(ImRaii.PushFont(UiBuilder.IconFont))
             {
-                if(ImGui.Button($"{FontAwesomeIcon.ArrowsSpin.ToIconString()}###select_rotate", new Vector2(buttonSize)))
-                    _overlayWindow.Operation = OPERATION.ROTATE;
+                if(ImGui.Button($"{FontAwesomeIcon.ArrowsSpin.ToIconString()}###select_rotate", new Vector2(buttonSize)) || InputService.IsKeyBindDown(KeyBindEvents.Posing_Rotate))
+                    _posingService.Operation = PosingOperation.Rotate;
             }
         }
         if(ImGui.IsItemHovered())
@@ -168,12 +169,12 @@ internal class PosingOverlayToolbarWindow : Window
         ImGui.SameLine();
 
 
-        using(ImRaii.PushColor(ImGuiCol.Text, _overlayWindow.Operation == OPERATION.SCALE ? UIConstants.ToggleButtonActive : UIConstants.ToggleButtonInactive))
+        using(ImRaii.PushColor(ImGuiCol.Text, _posingService.Operation == PosingOperation.Scale ? UIConstants.ToggleButtonActive : UIConstants.ToggleButtonInactive))
         {
             using(ImRaii.PushFont(UiBuilder.IconFont))
             {
-                if(ImGui.Button($"{FontAwesomeIcon.ExpandAlt.ToIconString()}###select_scale", new Vector2(buttonSize)))
-                    _overlayWindow.Operation = OPERATION.SCALE;
+                if(ImGui.Button($"{FontAwesomeIcon.ExpandAlt.ToIconString()}###select_scale", new Vector2(buttonSize)) || InputService.IsKeyBindDown(KeyBindEvents.Posing_Scale))
+                    _posingService.Operation = PosingOperation.Scale;
             }
         }
         if(ImGui.IsItemHovered())

--- a/Brio/UI/Windows/Specialized/PosingOverlayWindow.cs
+++ b/Brio/UI/Windows/Specialized/PosingOverlayWindow.cs
@@ -22,7 +22,6 @@ namespace Brio.UI.Windows.Specialized;
 
 internal class PosingOverlayWindow : Window, IDisposable
 {
-    public OPERATION Operation = OPERATION.ROTATE;
 
     private readonly EntityManager _entityManager;
     private readonly CameraService _cameraService;
@@ -416,7 +415,7 @@ internal class PosingOverlayWindow : Window, IDisposable
         if(ImGuizmo.Manipulate(
             ref worldViewMatrix.M11,
             ref projectionMatrix.M11,
-            Operation,
+            _posingService.Operation.AsGizmoOperation(),
             _posingService.CoordinateMode.AsGizmoMode(),
             ref matrix.M11
         ))


### PR DESCRIPTION
A few convenient hotkeys for switching between translation, rotation and scale operation modes of the gizmo. Are not bound to any key combination by default.

![image](https://github.com/Etheirys/Brio/assets/4562424/173b2c5c-c792-448b-a62c-ca27944f8d99)