### PR TITLE
Signature fix for 6.58

### DIFF
--- a/Brio/Brio.csproj
+++ b/Brio/Brio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0-windows</TargetFramework>
+		<TargetFramework>net8.0-windows</TargetFramework>
 		<Platforms>x64</Platforms>
 		<Nullable>enable</Nullable>
 		<LangVersion>preview</LangVersion>

--- a/Brio/Game/Posing/SkeletonService.cs
+++ b/Brio/Game/Posing/SkeletonService.cs
@@ -58,7 +58,7 @@ internal unsafe class SkeletonService : IDisposable
         _updateBonePhysicsHook = hooking.HookFromAddress<UpdateBonePhysicsDelegate>(scanner.ScanText(updateBonePhysicsAddress), UpdateBonePhysicsDetour);
         _updateBonePhysicsHook.Enable();
 
-        var finalizeSkeletonsHook = "48 8B 0D B1 73 10 02 E9 44 7D 32"; // Framework.TaskRenderGraphicsRender
+        var finalizeSkeletonsHook = "48 8B 0D B1 ?? 10 02 E9 ?? 7D 32"; // Framework.TaskRenderGraphicsRender
         _finalizeSkeletonsHook = hooking.HookFromAddress<FinalizeSkeletonsDelegate>(scanner.ScanText(finalizeSkeletonsHook), FinalizeSkeletonsHook);
         _finalizeSkeletonsHook.Enable();
 


### PR DESCRIPTION
Simple change. The .Net version was bumped too to be able to compile it.
The bytes that were different between the previous version and the current one were masked to try to avoid this from happening again.
All other signatures seem to be working properly, they all give one match in the current executable.