### PR TITLE
Handle Attachment Error

### DIFF
--- a/Brio/UI/Controls/Editors/PosingTransformEditor.cs
+++ b/Brio/UI/Controls/Editors/PosingTransformEditor.cs
@@ -22,33 +22,34 @@ internal class PosingTransformEditor
 
         _compactMode = compactMode;
 
+        Vector2 style;
         if(_compactMode)
-            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(4, 3));
+            style = new Vector2(4, 3);
         else
-            ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(4, 5));
+            style = new Vector2(4, 5);
 
-        using(ImRaii.PushId(id))
+        using(ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, style))
         {
-            selected.Switch(
-                bone =>
-                {
-                    var realBone = posingCapability.SkeletonPosing.GetBone(bone);
-                    if(realBone != null && realBone.Skeleton.IsValid)
+            using(ImRaii.PushId(id))
+            {
+                selected.Switch(
+                    bone =>
                     {
-                        DrawBoneTransformEditor(posingCapability, bone);
-                    }
-                    else
-                    {
-                        DrawModelTransformEditor(posingCapability);
-                    }
-                },
-                _ => DrawModelTransformEditor(posingCapability),
-                _ => DrawModelTransformEditor(posingCapability)
-            );
+                        var realBone = posingCapability.SkeletonPosing.GetBone(bone);
+                        if(realBone != null && realBone.Skeleton.IsValid)
+                        {
+                            DrawBoneTransformEditor(posingCapability, bone);
+                        }
+                        else
+                        {
+                            DrawModelTransformEditor(posingCapability);
+                        }
+                    },
+                    _ => DrawModelTransformEditor(posingCapability),
+                    _ => DrawModelTransformEditor(posingCapability)
+                );
+            }
         }
-
-        ImGui.PopStyleVar();
-
     }
 
     private void DrawBoneTransformEditor(PosingCapability posingCapability, BonePoseInfoId boneId)

--- a/Brio/UI/Widgets/Core/WidgetHelpers.cs
+++ b/Brio/UI/Widgets/Core/WidgetHelpers.cs
@@ -12,7 +12,12 @@ internal class WidgetHelpers
     public static void DrawBodies(IEnumerable<Capability> capabilities)
     {
         foreach(var w in capabilities)
+        {
+            if(!w.Entity.IsAttached)
+                break;
+
             DrawBody(w);
+        }            
     }
 
     public static void DrawBody(Capability capability) => DrawBody(capability.Widget);
@@ -50,6 +55,9 @@ internal class WidgetHelpers
         bool drewAny = false;
         foreach(var w in capabilities)
         {
+            if(!w.Entity.IsAttached)
+                break;
+
             drewAny = true;
             DrawQuickIconSection(w);
             ImGui.SameLine();


### PR DESCRIPTION
This addresses 2 things:

It's possible for an entity to become detached/inactive/destroyed during the tight UI loop where the quick access icons and capability widgets are drawn for an entity. The most obvious example of this is when you destroy it yourself. 
For example, if you use the quick access icon to destroy an actor, the entity will no longer exist when trying to draw the capability widgets later in the frame. 
I think it's mostly safe to assume that within a quick access icon or a capability widget things will be handled (or at least any case that doesn't should be made to) so the only case that needs to be handled is where an earlier quick access or widget invalidates the entity (and thus detaches and disposes the entity, and disposes the capabilities). In those cases, it should just early exit and move on to the next entity.

The second thing this addresses a style leak that could occur during the scenario I described above. Obviously that won't happen anymore for the specific case which bought the leak to my attention, but it probably makes sense to make the style push/pops as robust as possible. There are quite a few elsewhere that should either be switched to RAII or wrapped in try/finally blocks most likely.

It's also conceivable the first issue could be triggered by another tool interacting with Brio (during actor create/redraw/destroy etc). Because FFXIV is mostly single threaded, and other plugins could have hooks on events, it's possible they could rip the entity out from under Brio.