### PR TITLE
VFX = 0 Filter for StatusEffects

### DIFF
--- a/Brio/UI/Controls/Selectors/StatusEffectSelector.cs
+++ b/Brio/UI/Controls/Selectors/StatusEffectSelector.cs
@@ -57,7 +57,7 @@ internal class StatusEffectSelector(string id) : Selector<StatusEffectSelectorHo
 
         ImGui.Image(tex.ImGuiHandle, iconSize);
         ImGui.SameLine();
-        ImGui.Text($"{item.Name}\n{item.RowId}\nVFX: {item.VFX.RowId} / Hit: {item.HitEffect.RowId}");
+        ImGui.Text($"{item.Name.ExtractText()}\n{item.RowId}\nVFX: {item.VFX.RowId} / Hit: {item.HitEffect.RowId}");
     }
 
     protected override int Compare(StatusEffectSelectorHolder sesh1, StatusEffectSelectorHolder sesh2)

--- a/Brio/UI/Controls/Selectors/StatusEffectSelector.cs
+++ b/Brio/UI/Controls/Selectors/StatusEffectSelector.cs
@@ -17,7 +17,7 @@ public class StatusEffectSelectorHolder
 internal class StatusEffectSelector(string id) : Selector<StatusEffectSelectorHolder>(id)
 {
     protected override Vector2 MinimumListSize { get; } = new(300, 300);
-    public bool _VFXLockEnabled = false;
+    public bool _VFXLockEnabled = true;
 
     protected override float EntrySize => ImGui.GetTextLineHeight() * 3f;
 
@@ -38,7 +38,7 @@ internal class StatusEffectSelector(string id) : Selector<StatusEffectSelectorHo
 		if(ImGui.Checkbox("###status_vfx_filter", ref this._VFXLockEnabled))
 		    UpdateList();
         ImGui.SameLine();
-        ImGui.Text("Filter out any Status whose VFX value is 0.");
+        ImGui.Text("Remove Status Effects that do not have a VFX.");
 
 	}
 

--- a/Brio/UI/Controls/Selectors/StatusEffectSelector.cs
+++ b/Brio/UI/Controls/Selectors/StatusEffectSelector.cs
@@ -1,4 +1,5 @@
 ﻿using Brio.Resources;
+using Brio.UI.Widgets.Actor;
 using Dalamud.Interface.Textures.TextureWraps;
 using ImGuiNET;
 using Lumina.Excel.Sheets;
@@ -10,11 +11,13 @@ namespace Brio.UI.Controls.Selectors;
 public class StatusEffectSelectorHolder
 {
     public Status Status { get; set; }
+    public bool _VFXLockEnabled { get; set; }
 }
 
 internal class StatusEffectSelector(string id) : Selector<StatusEffectSelectorHolder>(id)
 {
     protected override Vector2 MinimumListSize { get; } = new(300, 300);
+    public bool _VFXLockEnabled = false;
 
     protected override float EntrySize => ImGui.GetTextLineHeight() * 3f;
 
@@ -27,6 +30,17 @@ internal class StatusEffectSelector(string id) : Selector<StatusEffectSelectorHo
             AddItem(new StatusEffectSelectorHolder { Status = item });
         }
     }
+
+	protected override void DrawOptions()
+	{
+		base.DrawOptions();
+
+		if(ImGui.Checkbox("###status_vfx_filter", ref this._VFXLockEnabled))
+		    UpdateList();
+        ImGui.SameLine();
+        ImGui.Text("Filter out any Status whose VFX value is 0.");
+
+	}
 
     protected override void DrawItem(StatusEffectSelectorHolder sesh, bool isHovered)
     {
@@ -63,10 +77,10 @@ internal class StatusEffectSelector(string id) : Selector<StatusEffectSelectorHo
     protected override bool Filter(StatusEffectSelectorHolder sesh, string search)
     {
         var item = sesh.Status;
+		if(_VFXLockEnabled && item.VFX.RowId == 0) return false;
 
         if(item.StatusCategory == 0)
             return false;
-
         var searchTerm = $"{item.Name} {item.RowId} {item.VFX.RowId} {item.HitEffect.RowId}";
 
         if(searchTerm.Contains(search, StringComparison.InvariantCultureIgnoreCase))

--- a/Brio/UI/Widgets/Actor/StatusEffectsWidget.cs
+++ b/Brio/UI/Widgets/Actor/StatusEffectsWidget.cs
@@ -53,7 +53,7 @@ internal class StatusEffectsWidget(StatusEffectCapability capability) : Widget<S
                     ImGui.SetCursorPos(position);
                     ImGui.Image(tex.ImGuiHandle, iconSize);
                     ImGui.SameLine();
-                    ImGui.Text($"{status.Name}\n{status.RowId}");
+                    ImGui.Text($"{status.Name.ExtractText()}\n{status.RowId}");
 
                     if(wasSelected)
                         _selectedStatus = (int)status.RowId;

--- a/Brio/UI/Widgets/Actor/StatusEffectsWidget.cs
+++ b/Brio/UI/Widgets/Actor/StatusEffectsWidget.cs
@@ -35,7 +35,8 @@ internal class StatusEffectsWidget(StatusEffectCapability capability) : Widget<S
             {
                 foreach(var status in statuses)
                 {
-                    if(_VFXLockEnabled && status.VFX.RowId == 0) break;
+                    if(_VFXLockEnabled && status.VFX.RowId == 0) continue;
+
                     bool selected = status.RowId == _selectedStatus;
 
                     IDalamudTextureWrap? tex = null;
@@ -85,7 +86,7 @@ internal class StatusEffectsWidget(StatusEffectCapability capability) : Widget<S
 
 		ImGui.Checkbox("###status_vfx_filter", ref _VFXLockEnabled);
 		if(ImGui.IsItemHovered())
-			ImGui.SetTooltip("Filter out any Status whose VFX value is 0.");
+			ImGui.SetTooltip("Hide Status Effects that have no VFX.");
 
         ImGui.SameLine();
 

--- a/Brio/UI/Widgets/Actor/StatusEffectsWidget.cs
+++ b/Brio/UI/Widgets/Actor/StatusEffectsWidget.cs
@@ -1,4 +1,5 @@
 ﻿using Brio.Capabilities.Actor;
+using Brio.Capabilities.Core;
 using Brio.Resources;
 using Brio.UI.Controls.Selectors;
 using Brio.UI.Controls.Stateless;
@@ -19,6 +20,7 @@ internal class StatusEffectsWidget(StatusEffectCapability capability) : Widget<S
     public override WidgetFlags Flags => WidgetFlags.DrawBody;
 
     private int _selectedStatus;
+    private bool _VFXLockEnabled = false;
 
     private static readonly StatusEffectSelector _globalStatusEffectSelector = new("global_status_selector");
 
@@ -33,6 +35,7 @@ internal class StatusEffectsWidget(StatusEffectCapability capability) : Widget<S
             {
                 foreach(var status in statuses)
                 {
+                    if(_VFXLockEnabled && status.VFX.RowId == 0) break;
                     bool selected = status.RowId == _selectedStatus;
 
                     IDalamudTextureWrap? tex = null;
@@ -77,6 +80,12 @@ internal class StatusEffectsWidget(StatusEffectCapability capability) : Widget<S
 
         if(ImBrio.FontIconButton("status_effects_remove", FontAwesomeIcon.Minus, "Remove Effect", isSelectedPlaying))
             Capability.RemoveStatus((ushort)_selectedStatus);
+
+        ImGui.SameLine();
+
+		ImGui.Checkbox("###status_vfx_filter", ref _VFXLockEnabled);
+		if(ImGui.IsItemHovered())
+			ImGui.SetTooltip("Filter out any Status whose VFX value is 0.");
 
         ImGui.SameLine();
 


### PR DESCRIPTION
Adds a simple option to filter out/hide the VFX whose value = 0 since they're basically useless for gposing.


https://github.com/user-attachments/assets/beab9e84-380b-4805-a13f-3a0a5ab38132