### PR TITLE
fix: brio camera not being added to `_createdCameras`

### DIFF
--- a/Brio/Game/Camera/VirtualCameraManager.cs
+++ b/Brio/Game/Camera/VirtualCameraManager.cs
@@ -108,7 +108,7 @@ public class VirtualCameraManager : IDisposable
         if(cameraID == 0)
             return false;
 
-        Brio.Log.Info("Destroying Brio camera " + _cameraId);
+        Brio.Log.Verbose("Destroying Brio camera " + _cameraId);
 
         if(_entityManager.TryGetEntity("cameras", out var ent))
         {

--- a/Brio/Game/Camera/VirtualCameraManager.cs
+++ b/Brio/Game/Camera/VirtualCameraManager.cs
@@ -55,16 +55,29 @@ public class VirtualCameraManager : IDisposable
 
             if(virtualCamera is null)
             {
-                if(cameraType == CameraType.Free)
+                switch(cameraType)
                 {
-                    camEnt.VirtualCamera.FreeCamValues.MovementSpeed = DefaultMovementSpeed;
-                    camEnt.VirtualCamera.FreeCamValues.MouseSensitivity = DefaultMouseSensitivity;
-                    camEnt.VirtualCamera.IsFreeCamera = true;
-                    camEnt.VirtualCamera.ActivateCamera();
-                    camEnt.VirtualCamera.ToFreeCam();
-                    camEnt.VirtualCamera.DeactivateCamera();
-
-                    _createdCameras.Add(_cameraId, camEnt);
+                    case CameraType.Free:
+                        camEnt.VirtualCamera.FreeCamValues.MovementSpeed = DefaultMovementSpeed;
+                        camEnt.VirtualCamera.FreeCamValues.MouseSensitivity = DefaultMouseSensitivity;
+                        camEnt.VirtualCamera.IsFreeCamera = true;
+                        camEnt.VirtualCamera.ActivateCamera();
+                        camEnt.VirtualCamera.ToFreeCam();
+                        camEnt.VirtualCamera.DeactivateCamera();
+                        _createdCameras.Add(_cameraId, camEnt);
+                        break;
+                    case CameraType.Brio:
+                        camEnt.VirtualCamera.IsFreeCamera = false;
+                        camEnt.VirtualCamera.ActivateCamera();
+                        camEnt.VirtualCamera.DeactivateCamera();
+                        _createdCameras.Add(_cameraId, camEnt);
+                        break;
+                    //case CameraType.Cutscene:
+                    //    unimplemented
+                    //    break;
+                    default:
+                        Brio.Log.Error($"Unknown camera type: {cameraType}");
+                        break;
                 }
             }
             else
@@ -95,7 +108,7 @@ public class VirtualCameraManager : IDisposable
         if(cameraID == 0)
             return false;
 
-        Brio.Log.Verbose("Destroying Brio camera " + _cameraId);
+        Brio.Log.Info("Destroying Brio camera " + _cameraId);
 
         if(_entityManager.TryGetEntity("cameras", out var ent))
         {


### PR DESCRIPTION
Fixes Issue #129 regarding Brio 0.5.0 / 0.5.0.1 where the deletion of a "Brio Camera" fails to occur due to missing logic in the `CreateCamera` code.

I've found that the code for the camera only had the implementation for Free Camera which works 100% while Brio Camera logic was missing. Due to this, deleting a Brio Camera was more difficult to delete as you would have to instead fiddle with several buttons in Brio to get it to work or disable and re-enable Brio for a new layout.

This fix adds missing logic to Brio cameras on the `CreateCamera` function to make the "Destroy" buttons work properly.