### PR TITLE
fix: autosave saving when off

### DIFF
--- a/Brio/Game/Core/AutoSaveService.cs
+++ b/Brio/Game/Core/AutoSaveService.cs
@@ -72,25 +72,28 @@ public class AutoSaveService : IDisposable
 
     private void AutoSave()
     {
-        try
+        if (ConfigurationService.Instance.Configuration.AutoSave.AutoSaveSystemEnabled)
         {
-            var scene = _sceneService.GenerateSceneFile();
+            try
+            {
+                var scene = _sceneService.GenerateSceneFile();
 
-            byte[] bytes = MessagePackSerializer.Serialize(scene);
+                byte[] bytes = MessagePackSerializer.Serialize(scene);
 
-            var path = Path.Combine(AutoSaveFolder, $"autosave-{DateTime.Now:yyyy-MM-dd}-{DateTime.Now:hh-mm-ss}.brioautosave");
-            Brio.Log.Verbose($"AutoSaving: {path}");
+                var path = Path.Combine(AutoSaveFolder, $"autosave-{DateTime.Now:yyyy-MM-dd}-{DateTime.Now:hh-mm-ss}.brioautosave");
+                Brio.Log.Verbose($"AutoSaving: {path}");
 
-            File.WriteAllBytes(path, bytes);
+                File.WriteAllBytes(path, bytes);
 
-            Brio.Log.Verbose($"AutoSaved!");
+                Brio.Log.Verbose($"AutoSaved!");
 
-            Update();
-            CleanOldSaves();
-        }
-        catch(Exception ex)
-        {
-            Brio.Log.Error(ex, "Exception AutoSaving!");
+                Update();
+                CleanOldSaves();
+            }
+            catch(Exception ex)
+            {
+                Brio.Log.Error(ex, "Exception AutoSaving!");
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug in Brio where, even if you have autosave off, the logs show that Brio continues to Autosave, not respecting the setting the user has chosen. All this PR does is first check if the user enabled auto-saving and if so, to execute the autosave code.