### PR TITLE
Library Feature: Spawn as new actor

### DIFF
--- a/Brio/Library/Sources/GameDataAppearanceEntry.cs
+++ b/Brio/Library/Sources/GameDataAppearanceEntry.cs
@@ -8,6 +8,7 @@ using Brio.UI;
 using Brio.UI.Controls.Stateless;
 using Dalamud.Interface.Textures.TextureWraps;
 using System;
+using ImGuiNET;
 
 namespace Brio.Library.Sources;
 
@@ -109,6 +110,8 @@ public class GameDataAppearanceEntry : ItemEntryBase
         base.DrawActions(isModal);
 
         ImBrio.DrawApplyToActor(_entityManager, SetAppearance);
+        ImGui.SameLine();
+        ImBrio.DrawSpawnActor(_entityManager, SetAppearance);
     }
 
     void SetAppearance(ActorEntity actorEntity)

--- a/Brio/Library/Sources/GameDataAppearanceEntry.cs
+++ b/Brio/Library/Sources/GameDataAppearanceEntry.cs
@@ -110,8 +110,6 @@ public class GameDataAppearanceEntry : ItemEntryBase
         base.DrawActions(isModal);
 
         ImBrio.DrawApplyToActor(_entityManager, SetAppearance);
-        ImGui.SameLine();
-        ImBrio.DrawSpawnActor(_entityManager, SetAppearance);
     }
 
     void SetAppearance(ActorEntity actorEntity)

--- a/Brio/UI/Controls/Stateless/ImBrio.ApplyToActor.cs
+++ b/Brio/UI/Controls/Stateless/ImBrio.ApplyToActor.cs
@@ -2,11 +2,13 @@
 using Brio.Entities.Actor;
 using ImGuiNET;
 using System;
+using System.Numerics;
 using Brio.Entities.Core;
 using Brio.Game.Actor;
 using Brio.Game.Actor.Extensions;
 using Brio.Game.Core;
 using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Interface;
 using Dalamud.Interface.Utility.Raii;
 
 namespace Brio.UI.Controls.Stateless;
@@ -23,7 +25,7 @@ public partial class ImBrio
         }
         else
         {
-            if(ImGui.Button($"Apply To"))
+            if(ImGui.Button($"Apply To {selectedActor.FriendlyName}"))
             {
                 callback?.Invoke(selectedActor);
             }
@@ -37,17 +39,18 @@ public partial class ImBrio
             using var _ = ImRaii.Disabled(true);
             ImGui.Button("Unable to Spawn");
         }
+        
 
-        if(ImGui.Button($"Spawn New Actor"))
+        if(FontIconButton(FontAwesomeIcon.Plus))
         {
             if(!spawnService.CreateCharacter(out var character, disableSpawnCompanion: true))
             {
                 Brio.Log.Error("Unable to spawn character");
                 return;
             }
-            
+
             unsafe bool IsReadyToDraw() => character.Native()->IsReadyToDraw();
-            
+
             Brio.Framework.RunUntilSatisfied(
                 IsReadyToDraw,
                 (_) =>
@@ -64,21 +67,9 @@ public partial class ImBrio
                 100,
                 dontStartFor: 2
             );
-            
-            //var entity = entityManager.AttachEntity(new Entity)
-            
-            // Brio.Framework.RunOnTick(() =>
-            //     {
-            //         var entity = entityManager.GetEntity(new EntityId(character)); 
-            //         if(entity is not ActorEntity actorEntity)
-            //         {
-            //             Brio.Log.Error($"Unable to get actor entity is: {entity?.GetType()} {entity}"); 
-            //             return;
-            //         }
-            //
-            //         callback.Invoke(actorEntity);
-            //     }
-            // );
         }
+        
+        if(ImGui.IsItemHovered())
+            ImGui.SetTooltip("Spawn As New Actor");
     }
 }

--- a/Brio/UI/Controls/Stateless/ImBrio.ApplyToActor.cs
+++ b/Brio/UI/Controls/Stateless/ImBrio.ApplyToActor.cs
@@ -19,9 +19,14 @@ public partial class ImBrio
     {
         if(entityManager.SelectedEntity is null || entityManager.SelectedEntity is not ActorEntity selectedActor)
         {
-            ImGui.BeginDisabled();
-            ImGui.Button($"Select an Actor");
-            ImGui.EndDisabled();
+            DrawSpawnActor(entityManager, callback);
+            
+            return;
+        }
+
+        if(ImGui.IsKeyDown(ImGuiKey.LeftCtrl) || ImGui.IsKeyDown(ImGuiKey.RightCtrl))
+        {
+            DrawSpawnActor(entityManager, callback);
         }
         else
         {
@@ -29,19 +34,24 @@ public partial class ImBrio
             {
                 callback?.Invoke(selectedActor);
             }
+
+
+            if(ImGui.IsItemHovered())
+                ImGui.SetTooltip("Hold Ctrl to spawn as a new actor");
         }
+
     }
 
-    public static void DrawSpawnActor(EntityManager entityManager, Action<ActorEntity> callback)
+    private static void DrawSpawnActor(EntityManager entityManager, Action<ActorEntity> callback)
     {
         if(!Brio.TryGetService(out ActorSpawnService spawnService))
         {
             using var _ = ImRaii.Disabled(true);
             ImGui.Button("Unable to Spawn");
         }
-        
 
-        if(FontIconButton(FontAwesomeIcon.Plus))
+
+        if(ImGui.Button("Spawn As New Actor"))
         {
             if(!spawnService.CreateCharacter(out var character, disableSpawnCompanion: true))
             {
@@ -68,8 +78,5 @@ public partial class ImBrio
                 dontStartFor: 2
             );
         }
-        
-        if(ImGui.IsItemHovered())
-            ImGui.SetTooltip("Spawn As New Actor");
     }
 }


### PR DESCRIPTION
From our discussions on discord earlier I have added the feature similar to quick spawning a library entry as a new actor.

![image](https://github.com/user-attachments/assets/4bcce74c-7d75-4922-8799-0a0911159a4a)

When holding ctrl (left or right) it will change to spawning as a new actor instead of applying to the currently selected character:

![image](https://github.com/user-attachments/assets/02b8471f-c502-4ac0-a27b-76684183b482)

It will also default to spawning as a new actor instead:

![image](https://github.com/user-attachments/assets/bc233af7-ca80-4c52-a9dc-417e06a54ecd)


If it is wanted to have as a individual button I can do that too.