### PR TITLE
Fixes C+ not being reverted on exiting gpose or dispose

### DIFF
--- a/Brio/Capabilities/Actor/ActorAppearanceCapability.cs
+++ b/Brio/Capabilities/Actor/ActorAppearanceCapability.cs
@@ -341,6 +341,7 @@ public class ActorAppearanceCapability : ActorCharacterCapability
 
         ResetCollection();
         _ = ResetAppearance();
+        ResetProfile();
     }
 
     private void OnPenumbraRedraw(int gameObjectId)
@@ -356,5 +357,6 @@ public class ActorAppearanceCapability : ActorCharacterCapability
 
         ResetCollection();
         _ = ResetAppearance();
+        ResetProfile();
     }
 }


### PR DESCRIPTION
C+ Profile was not being reset on gpose exit thus forcing user to go back into gpose to press the reset button manually or go with other ways ways to get rid of the temporary C+ profile like unloading C+ or restarting the game.