### PR TITLE
feat: add camera cloning for brio + free cams

### DIFF
--- a/Brio/Game/Camera/VirtualCameraManager.cs
+++ b/Brio/Game/Camera/VirtualCameraManager.cs
@@ -126,6 +126,7 @@ public class VirtualCameraManager : IDisposable
                 if(oldCamEnt.CameraType == CameraType.Free)
                 {
                     newCam.VirtualCamera.Position = oldCam.Position;
+                    newCam.VirtualCamera.IsFreeCamera = true;
                 }
                 else
                 {

--- a/Brio/Game/Camera/VirtualCameraManager.cs
+++ b/Brio/Game/Camera/VirtualCameraManager.cs
@@ -5,6 +5,7 @@ using Brio.Game.GPose;
 using Brio.Game.Input;
 using Dalamud.Game.ClientState.Keys;
 using Microsoft.Extensions.DependencyInjection;
+using Swan;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
@@ -100,6 +101,61 @@ public class VirtualCameraManager : IDisposable
 
             return (true, _cameraId);
         }
+        return (false, -1);
+    }
+
+    public (bool, int) CloneCamera(int cameraID)
+    {
+        Brio.Log.Verbose($"Cloning camera {cameraID}");
+
+        if(_entityManager.TryGetEntity("cameras", out var ent))
+        {
+            if(_createdCameras.TryGetValue(cameraID, out CameraEntity? oldCamEnt))
+            {
+                CurrentCamera?.DeactivateCamera();
+
+                _cameraId++;
+
+                var oldCam = oldCamEnt.VirtualCamera;
+                var newCam = ActivatorUtilities.CreateInstance<CameraEntity>(_serviceProvider, _cameraId, oldCamEnt.CameraType);
+                _entityManager.AttachEntity(newCam, ent);
+
+                oldCam.CopyPropertiesTo(newCam.VirtualCamera);
+                newCam.VirtualCamera.Rotation = oldCam.Rotation;
+
+                if(oldCamEnt.CameraType == CameraType.Free)
+                {
+                    newCam.VirtualCamera.Position = oldCam.Position;
+                }
+                else
+                {
+                    newCam.VirtualCamera.PositionOffset = oldCam.PositionOffset;
+                    newCam.VirtualCamera.Angle = oldCam.Angle;
+                    newCam.VirtualCamera.Pan = oldCam.Pan;
+                }
+
+                _createdCameras.Add(_cameraId, newCam);
+                CurrentCamera?.ActivateCamera();
+                _entityManager.SetSelectedEntity(newCam);
+
+                if(oldCamEnt.CameraType == CameraType.Free)
+                {
+                    newCam.VirtualCamera.FreeCamValues.DelimitAngle = oldCam.FreeCamValues.DelimitAngle;
+                    newCam.VirtualCamera.FreeCamValues.MovementSpeed = oldCam.FreeCamValues.MovementSpeed;
+                    newCam.VirtualCamera.FreeCamValues.MouseSensitivity = oldCam.FreeCamValues.MouseSensitivity;
+                }
+                else
+                {
+                    newCam.VirtualCamera.DisableCollision = oldCam.DisableCollision;
+                    newCam.VirtualCamera.DelimitCamera = oldCam.DelimitCamera;
+                }
+
+                return (true, _cameraId);
+            }
+            Brio.Log.Error($"Camera with ID {cameraID} not found");
+            return (false, -1);
+        }
+        Brio.Log.Error("No camera container found");
         return (false, -1);
     }
 

--- a/Brio/UI/Controls/Editors/PosingTransformEditor.cs
+++ b/Brio/UI/Controls/Editors/PosingTransformEditor.cs
@@ -48,10 +48,6 @@ public class PosingTransformEditor
                     _ => DrawModelTransformEditor(posingCapability, compactMode)
                 );
 
-                ImBrio.Icon(FontAwesomeIcon.ArrowsLeftRightToLine);
-                ImGui.SameLine();
-                ImBrio.DragFloat($"##transformSpeed_1", ref posingCapability.AdjusterOffset, 0.01f, "Offset");
-
                 if(posingCapability.Actor.IsProp == false)
                 {
                     ImGui.Separator();
@@ -126,7 +122,6 @@ public class PosingTransformEditor
         bool anyActive = false;
 
         var bone = posingCapability.SkeletonPosing.GetBone(boneId);
-        var offset = posingCapability.AdjusterOffset;
         var bonePose = bone is not null ? posingCapability.SkeletonPosing.GetBonePose(boneId) : null;
 
         var propagate = bonePose?.DefaultPropagation ?? TransformComponents.None;
@@ -144,9 +139,9 @@ public class PosingTransformEditor
             }
         }
 
-        (var pdidChange, var panyActive) = ImBrio.DragFloat3($"###_transformPosition_0", ref realTransform.Position, offset, FontAwesomeIcon.ArrowsUpDownLeftRight, "Position", enableExpanded: compactMode);
-        (var rdidChange, var ranyActive) = ImBrio.DragFloat3($"###_transformRotation_0", ref realEuler, offset, FontAwesomeIcon.ArrowsSpin, "Rotation", enableExpanded: compactMode);
-        (var sdidChange, var sanyActive) = ImBrio.DragFloat3($"###_transformScale_0", ref realTransform.Scale, offset, FontAwesomeIcon.ExpandAlt, "Scale", enableExpanded: compactMode);
+        (var pdidChange, var panyActive) = ImBrio.DragFloat3($"###_transformPosition_0", ref realTransform.Position, 0.1f, FontAwesomeIcon.ArrowsUpDownLeftRight, "Position", enableExpanded: compactMode);
+        (var rdidChange, var ranyActive) = ImBrio.DragFloat3($"###_transformRotation_0", ref realEuler, 1f, FontAwesomeIcon.ArrowsSpin, "Rotation", enableExpanded: compactMode);
+        (var sdidChange, var sanyActive) = ImBrio.DragFloat3($"###_transformScale_0", ref realTransform.Scale, 0.1f, FontAwesomeIcon.ExpandAlt, "Scale", enableExpanded: compactMode);
 
         didChange |= pdidChange |= rdidChange |= sdidChange;
         anyActive |= panyActive |= ranyActive |= sanyActive;
@@ -181,15 +176,14 @@ public class PosingTransformEditor
     {
         var before = posingCapability.ModelPosing.Transform;
         var isProp = posingCapability.Actor.IsProp;
-        var offset = posingCapability.AdjusterOffset;
         var realTransform = _trackingTransform ?? before;
         var realEuler = _trackingEuler ?? before.Rotation.ToEuler();
 
         bool didChange = false;
         bool anyActive = false;
 
-        (var pdidChange, var panyActive) = ImBrio.DragFloat3($"###_transformPosition_1", ref realTransform.Position, offset, FontAwesomeIcon.ArrowsUpDownLeftRight, "Position", enableExpanded: compactMode);
-        (var rdidChange, var ranyActive) = ImBrio.DragFloat3($"###_transformRotation_1", ref realEuler, offset, FontAwesomeIcon.ArrowsSpin, "Rotation", enableExpanded: compactMode);
+        (var pdidChange, var panyActive) = ImBrio.DragFloat3($"###_transformPosition_1", ref realTransform.Position, 0.1f, FontAwesomeIcon.ArrowsUpDownLeftRight, "Position", enableExpanded: compactMode);
+        (var rdidChange, var ranyActive) = ImBrio.DragFloat3($"###_transformRotation_1", ref realEuler, 5.0f, FontAwesomeIcon.ArrowsSpin, "Rotation", enableExpanded: compactMode);
 
         bool sdidChange = false;
         bool sanyActive = false;
@@ -207,10 +201,10 @@ public class PosingTransformEditor
             float entryWidth = (size.X - (ImGui.GetStyle().ItemSpacing.X * 2));
             ImGui.SetNextItemWidth(entryWidth);
 
-            (sanyActive, sdidChange) = ImBrio.DragFloat($"##transformScale", ref realTransform.Scale.X, offset / 10);
+            (sanyActive, sdidChange) = ImBrio.DragFloat($"##transformScale", ref realTransform.Scale.X, 0.1f / 10);
         }
         else
-            (sdidChange, sanyActive) = ImBrio.DragFloat3($"###_transformScale_1", ref realTransform.Scale, offset, FontAwesomeIcon.ExpandAlt, "Scale", enableExpanded: compactMode);
+            (sdidChange, sanyActive) = ImBrio.DragFloat3($"###_transformScale_1", ref realTransform.Scale, 0.1f, FontAwesomeIcon.ExpandAlt, "Scale", enableExpanded: compactMode);
 
         didChange |= pdidChange |= rdidChange |= sdidChange;
         anyActive |= panyActive |= ranyActive |= sanyActive;

--- a/Brio/UI/Controls/Editors/PosingTransformEditor.cs
+++ b/Brio/UI/Controls/Editors/PosingTransformEditor.cs
@@ -48,6 +48,10 @@ public class PosingTransformEditor
                     _ => DrawModelTransformEditor(posingCapability, compactMode)
                 );
 
+                ImBrio.Icon(FontAwesomeIcon.ArrowsLeftRightToLine);
+                ImGui.SameLine();
+                ImBrio.DragFloat($"##transformSpeed_1", ref posingCapability.AdjusterOffset, 0.01f, "Offset");
+
                 if(posingCapability.Actor.IsProp == false)
                 {
                     ImGui.Separator();
@@ -122,6 +126,7 @@ public class PosingTransformEditor
         bool anyActive = false;
 
         var bone = posingCapability.SkeletonPosing.GetBone(boneId);
+        var offset = posingCapability.AdjusterOffset;
         var bonePose = bone is not null ? posingCapability.SkeletonPosing.GetBonePose(boneId) : null;
 
         var propagate = bonePose?.DefaultPropagation ?? TransformComponents.None;
@@ -139,9 +144,9 @@ public class PosingTransformEditor
             }
         }
 
-        (var pdidChange, var panyActive) = ImBrio.DragFloat3($"###_transformPosition_0", ref realTransform.Position, 0.1f, FontAwesomeIcon.ArrowsUpDownLeftRight, "Position", enableExpanded: compactMode);
-        (var rdidChange, var ranyActive) = ImBrio.DragFloat3($"###_transformRotation_0", ref realEuler, 1f, FontAwesomeIcon.ArrowsSpin, "Rotation", enableExpanded: compactMode);
-        (var sdidChange, var sanyActive) = ImBrio.DragFloat3($"###_transformScale_0", ref realTransform.Scale, 0.1f, FontAwesomeIcon.ExpandAlt, "Scale", enableExpanded: compactMode);
+        (var pdidChange, var panyActive) = ImBrio.DragFloat3($"###_transformPosition_0", ref realTransform.Position, offset, FontAwesomeIcon.ArrowsUpDownLeftRight, "Position", enableExpanded: compactMode);
+        (var rdidChange, var ranyActive) = ImBrio.DragFloat3($"###_transformRotation_0", ref realEuler, offset, FontAwesomeIcon.ArrowsSpin, "Rotation", enableExpanded: compactMode);
+        (var sdidChange, var sanyActive) = ImBrio.DragFloat3($"###_transformScale_0", ref realTransform.Scale, offset, FontAwesomeIcon.ExpandAlt, "Scale", enableExpanded: compactMode);
 
         didChange |= pdidChange |= rdidChange |= sdidChange;
         anyActive |= panyActive |= ranyActive |= sanyActive;
@@ -176,14 +181,15 @@ public class PosingTransformEditor
     {
         var before = posingCapability.ModelPosing.Transform;
         var isProp = posingCapability.Actor.IsProp;
+        var offset = posingCapability.AdjusterOffset;
         var realTransform = _trackingTransform ?? before;
         var realEuler = _trackingEuler ?? before.Rotation.ToEuler();
 
         bool didChange = false;
         bool anyActive = false;
 
-        (var pdidChange, var panyActive) = ImBrio.DragFloat3($"###_transformPosition_1", ref realTransform.Position, 0.1f, FontAwesomeIcon.ArrowsUpDownLeftRight, "Position", enableExpanded: compactMode);
-        (var rdidChange, var ranyActive) = ImBrio.DragFloat3($"###_transformRotation_1", ref realEuler, 5.0f, FontAwesomeIcon.ArrowsSpin, "Rotation", enableExpanded: compactMode);
+        (var pdidChange, var panyActive) = ImBrio.DragFloat3($"###_transformPosition_1", ref realTransform.Position, offset, FontAwesomeIcon.ArrowsUpDownLeftRight, "Position", enableExpanded: compactMode);
+        (var rdidChange, var ranyActive) = ImBrio.DragFloat3($"###_transformRotation_1", ref realEuler, offset, FontAwesomeIcon.ArrowsSpin, "Rotation", enableExpanded: compactMode);
 
         bool sdidChange = false;
         bool sanyActive = false;
@@ -201,10 +207,10 @@ public class PosingTransformEditor
             float entryWidth = (size.X - (ImGui.GetStyle().ItemSpacing.X * 2));
             ImGui.SetNextItemWidth(entryWidth);
 
-            (sanyActive, sdidChange) = ImBrio.DragFloat($"##transformScale", ref realTransform.Scale.X, 0.1f / 10);
+            (sanyActive, sdidChange) = ImBrio.DragFloat($"##transformScale", ref realTransform.Scale.X, offset / 10);
         }
         else
-            (sdidChange, sanyActive) = ImBrio.DragFloat3($"###_transformScale_1", ref realTransform.Scale, 0.1f, FontAwesomeIcon.ExpandAlt, "Scale", enableExpanded: compactMode);
+            (sdidChange, sanyActive) = ImBrio.DragFloat3($"###_transformScale_1", ref realTransform.Scale, offset, FontAwesomeIcon.ExpandAlt, "Scale", enableExpanded: compactMode);
 
         didChange |= pdidChange |= rdidChange |= sdidChange;
         anyActive |= panyActive |= ranyActive |= sanyActive;

--- a/Brio/UI/Widgets/Camera/CameraContainerWidget.cs
+++ b/Brio/UI/Widgets/Camera/CameraContainerWidget.cs
@@ -34,10 +34,10 @@ public class CameraContainerWidget(CameraContainerCapability capability) : Widge
 
             using(ImRaii.Disabled(hasSelection == false))
             {
-                using(ImRaii.Disabled(true))
+                using(ImRaii.Disabled(_selectedEntity?.VirtualCamera.CameraID == null))
                     if(ImBrio.FontIconButton("CameraLifetime_clone", FontAwesomeIcon.Clone, "Clone Camera"))
                     {
-
+                        Capability.VirtualCameraManager.CloneCamera(_selectedEntity!.VirtualCamera.CameraID);
                     }
 
                 ImGui.SameLine();

--- a/Brio/UI/Widgets/Camera/CameraLifetimeWidet.cs
+++ b/Brio/UI/Widgets/Camera/CameraLifetimeWidet.cs
@@ -27,11 +27,10 @@ public class CameraLifetimeWidget(CameraLifetimeCapability capability) : Widget<
 
             ImGui.SameLine();
 
-            using(ImRaii.Disabled(true))
-                if(ImBrio.FontIconButton("CameraLifetime_clone", FontAwesomeIcon.Clone, "Clone Camera", Capability.CanClone))
-                {
-
-                }
+            if(ImBrio.FontIconButton("CameraLifetime_clone", FontAwesomeIcon.Clone, "Clone Camera", Capability.CanClone))
+            {
+                Capability.VirtualCameraManager.CloneCamera(Capability.CameraEntity.CameraID);
+            }
 
             ImGui.SameLine();
 
@@ -71,11 +70,10 @@ public class CameraLifetimeWidget(CameraLifetimeCapability capability) : Widget<
 
         if(Capability.CanClone)
         {
-            using(ImRaii.Disabled(true))
-                if(ImGui.MenuItem("Clone###CameraLifetime_clone"))
-                {
-
-                }
+            if(ImGui.MenuItem("Clone###CameraLifetime_clone"))
+            {
+                Capability.VirtualCameraManager.CloneCamera(Capability.CameraEntity.CameraID);
+            }
         }
 
         if(Capability.CanDestroy)


### PR DESCRIPTION
Noticed in a conversation in Aetherworks about cloning cameras being absent and that apparently it had some bugs initially back in 0.5.0.
> Yep this is known I was wondering when someone would say something, there was alot of bugs with cloning cameras so I removed it before 0.5.0 came out, ...

This PR basically adds the cloning implementation for Brio and Free Cameras whilst keeping everything (minus Enable Movement for Free Cameras) how it was originally. While I do not know if this was how the code was originally or if this still causes the same 0.5.0 bugs from prior, thought I throw this in.