### PR TITLE
fix: importing props/mounts in projects

### DIFF
--- a/Brio/Capabilities/Actor/ActorAppearanceCapability.cs
+++ b/Brio/Capabilities/Actor/ActorAppearanceCapability.cs
@@ -212,11 +212,11 @@ public class ActorAppearanceCapability : ActorCharacterCapability
         var currentAppearance = CurrentAppearance;
         BrioHuman.ShaderParams* shaders = Character.GetShaderParams();
 
-        ActorAppearanceExtended actor = new()
+        ActorAppearanceExtended actor = new() { Appearance = currentAppearance };
+        if(shaders != null)
         {
-            Appearance = currentAppearance,
-            ShaderParams = *shaders
-        };
+            actor.ShaderParams = *shaders;
+        }
 
         AnamnesisCharaFile appearance = actor;
         ResourceProvider.Instance.SaveFileDocument(file, appearance);

--- a/Brio/Files/ActorFile.cs
+++ b/Brio/Files/ActorFile.cs
@@ -4,6 +4,7 @@ using Brio.Core;
 using Brio.Entities.Actor;
 using Brio.Game.Actor.Appearance;
 using Brio.Game.Actor.Extensions;
+using Brio.Game.Actor.Interop;
 using Brio.Game.Types;
 using MessagePack;
 using System;
@@ -39,10 +40,19 @@ public class ActorFile
         var posingCapability = actorEntity.GetCapability<PosingCapability>();
         var modelCapability = actorEntity.GetCapability<ModelPosingCapability>();
 
+        ActorAppearanceExtended anaCharaFile = new() { Appearance = appearanceCapability.CurrentAppearance };
+        BrioHuman.ShaderParams* shaderParams = appearanceCapability.Character.GetShaderParams();
+
+        // append shader params to appearance if they exist
+        if(shaderParams is not null)
+        {
+            anaCharaFile.ShaderParams = *shaderParams;
+        }
+
         var actorFile = new ActorFile
         {
             Name = actorEntity.RawName,
-            AnamnesisCharaFile = new ActorAppearanceExtended { Appearance = appearanceCapability.CurrentAppearance, ShaderParams = *appearanceCapability.Character.GetShaderParams() },
+            AnamnesisCharaFile = anaCharaFile,
             PoseFile = posingCapability.GeneratePoseFile(),
             IsProp = actorEntity.IsProp,
             PropData = new PropData

--- a/Brio/Files/AnamnesisCharaFile.cs
+++ b/Brio/Files/AnamnesisCharaFile.cs
@@ -247,18 +247,21 @@ public class AnamnesisCharaFile : JsonDocumentBase
             // Extended Appearance
             Transparency = appearance.ExtendedAppearance.Transparency,
             HeightMultiplier = appearance.ExtendedAppearance.HeightMultiplier,
-
-            SkinColor = shaders.SkinColor,
-            SkinGloss = shaders.SkinGloss,
-            LeftEyeColor = shaders.LeftEyeColor,
-            RightEyeColor = shaders.RightEyeColor,
-            HairColor = shaders.HairColor,
-            HairGloss = shaders.HairGloss,
-            HairHighlight = shaders.HairHighlight,
-            MouthColor = shaders.MouthColor,
-            MuscleTone = shaders.MuscleTone,
-            LimbalRingColor = shaders.FeatureColor,
         };
+
+        if(shaders.HasValue)
+        {
+            charaFile.SkinColor = shaders.Value.SkinColor;
+            charaFile.SkinGloss = shaders.Value.SkinGloss;
+            charaFile.LeftEyeColor = shaders.Value.LeftEyeColor;
+            charaFile.RightEyeColor = shaders.Value.RightEyeColor;
+            charaFile.HairColor = shaders.Value.HairColor;
+            charaFile.HairGloss = shaders.Value.HairGloss;
+            charaFile.HairHighlight = shaders.Value.HairHighlight;
+            charaFile.MouthColor = shaders.Value.MouthColor;
+            charaFile.MuscleTone = shaders.Value.MuscleTone;
+            charaFile.LimbalRingColor = shaders.Value.FeatureColor;
+        }
 
         return charaFile;
     }

--- a/Brio/Game/Actor/Appearance/ActorAppearance.cs
+++ b/Brio/Game/Actor/Appearance/ActorAppearance.cs
@@ -337,5 +337,5 @@ public struct ActorAppearance()
 public struct ActorAppearanceExtended
 {
     public ActorAppearance Appearance;
-    public BrioHuman.ShaderParams ShaderParams;
+    public BrioHuman.ShaderParams? ShaderParams;
 }

--- a/Brio/Game/Scene/SceneService.cs
+++ b/Brio/Game/Scene/SceneService.cs
@@ -170,10 +170,20 @@ public class SceneService(EntityManager _entityManager, VirtualCameraManager _vi
 
         await _framework.RunOnTick(async () =>
         {
-
-            if(actorFile.AnamnesisCharaFile.IsExtendedAppearanceValid)
+            // only import shaders if the appearance is valid and it's not a prop (characters only)
+            if(actorFile.AnamnesisCharaFile.IsExtendedAppearanceValid && !actorFile.IsProp)
+            {
                 BrioUtilities.ImportShadersFromFile(ref appearanceCapability._modelShaderOverride, actorFile.AnamnesisCharaFile);
-            await appearanceCapability.SetAppearance(actorFile.AnamnesisCharaFile, AppearanceImportOptions.All);
+                await appearanceCapability.SetAppearance(actorFile.AnamnesisCharaFile, AppearanceImportOptions.All);
+            }
+            else if(actorFile.IsProp) // if it's a prop, only import the appearance
+            {
+                await appearanceCapability.SetAppearance(actorFile.AnamnesisCharaFile, AppearanceImportOptions.Customize);
+            }
+            else // chars with invalid extended appearances
+            {
+                await appearanceCapability.SetAppearance(actorFile.AnamnesisCharaFile, AppearanceImportOptions.Default);
+            }
 
             await _framework.RunOnTick(async () =>
             {
@@ -182,7 +192,7 @@ public class SceneService(EntityManager _entityManager, VirtualCameraManager _vi
                     mountPose = true;
 
                 if(mountPose == false)
-                    posingCapability.ImportPose(actorFile.PoseFile, asScene: true);
+                    posingCapability.ImportPose(actorFile.PoseFile, asScene: true, asProp: actorFile.IsProp);
 
                 if(attachedActor.HasCapability<CompanionCapability>() == true && actorFile.HasChild && actorFile.Child is not null)
                 {
@@ -191,20 +201,20 @@ public class SceneService(EntityManager _entityManager, VirtualCameraManager _vi
                     companionCapability.SetCompanion(actorFile.Child.Companion);
 
                     await _framework.RunOnTick(() =>
+                    {
+                        if(actorFile.Child.PoseFile is not null)
                         {
-                            if(actorFile.Child.PoseFile is not null)
+                            var companionEntity = companionCapability.GetCompanionAsEntity();
+
+                            if(companionEntity is not null && companionEntity.TryGetCapability<PosingCapability>(out var posingCapability))
                             {
-                                var companionEntity = companionCapability.GetCompanionAsEntity();
-
-                                if(companionEntity is not null && companionEntity.TryGetCapability<PosingCapability>(out var posingCapability))
-                                {
-                                    posingCapability.ImportPose(actorFile.Child.PoseFile, asScene: true, freezeOnLoad: true);
-                                }
+                                posingCapability.ImportPose(actorFile.Child.PoseFile, asScene: true, freezeOnLoad: true, asProp: actorFile.IsProp);
                             }
+                        }
 
-                            if(mountPose == true)
-                                posingCapability.ImportPose(actorFile.PoseFile, asScene: true);
-                        });
+                        if(mountPose == true)
+                            posingCapability.ImportPose(actorFile.PoseFile, asScene: true, asProp: actorFile.IsProp);
+                    });
                 }
             }, delayTicks: 10); // I don't like having to set delayTicks to this but I don't think I have another way without more rework
         });


### PR DESCRIPTION
This addresses two issues reported by Holo in Aetherworks where the Shader code would apply to props and break mounts during a project import.

The main cause of the issue was that props/mounts don't really have a extended appearance and thus:
1. If the actorFile is a prop, the shader code applies and defaults to (what I assume is your actual character) a generic character appearing alongside the prop itself. 
2. When saving a project, the ShaderParams argurment is required which can cause saving issues for props/mounts.

For 1, all that needed to be done is expand the if calls for props and add a fallback result for chars with bad shaders. For 2, I made the argument for shaders in the ActorExtendedAppearance optional for.