### PR TITLE
chore: camera adjustments

### DIFF
--- a/Brio/Core/BrioUtilities.cs
+++ b/Brio/Core/BrioUtilities.cs
@@ -23,11 +23,17 @@ public static class BrioUtilities
 
     public static float DegreesToRadians(float degrees)
     {
+        if(degrees == 0)
+            return 0;
+
         return degrees * (float)(System.Math.PI / 180);
     }
 
     public static float RadiansToDegrees(float radians)
     {
+        if(radians == 0)
+            return 0;
+
         return radians * (float)(180 / System.Math.PI);
     }
 }

--- a/Brio/Core/BrioUtilities.cs
+++ b/Brio/Core/BrioUtilities.cs
@@ -20,4 +20,14 @@ public static class BrioUtilities
         modelShaderOverride.RightEyeColor = shaderParams.RightEyeColor;
         modelShaderOverride.FeatureColor = shaderParams.FeatureColor;
     }
+
+    public static float DegreesToRadians(float degrees)
+    {
+        return degrees * (float)(System.Math.PI / 180);
+    }
+
+    public static float RadiansToDegrees(float radians)
+    {
+        return radians * (float)(180 / System.Math.PI);
+    }
 }

--- a/Brio/Game/Camera/VirtualCameraManager.cs
+++ b/Brio/Game/Camera/VirtualCameraManager.cs
@@ -273,42 +273,22 @@ public class VirtualCameraManager : IDisposable
         // Invert logic around the 90 degree pivot points
         // (Similar to XIV's Default Camera)
         if(keyboardFrame->IsKeyDown(VirtualKey.A, true))
-        {
             if(CurrentCamera.IsFreeCamera)
-            {
                 if(CurrentCamera.PivotRotation < BrioUtilities.DegreesToRadians(-90) || CurrentCamera.PivotRotation > BrioUtilities.DegreesToRadians(90))
-                {
                     leftRight += 1;
-                }
                 else
-                {
                     leftRight -= 1;
-                }
-            }
             else
-            {
                 leftRight += 1;
-            }
-        }
 
         if(keyboardFrame->IsKeyDown(VirtualKey.D, true))
-        {
             if(CurrentCamera.IsFreeCamera)
-            {
                 if(CurrentCamera.PivotRotation < BrioUtilities.DegreesToRadians(-90) || CurrentCamera.PivotRotation > BrioUtilities.DegreesToRadians(90))
-                {
                     leftRight -= 1;
-                }
                 else
-                {
                     leftRight += 1;
-                }
-            }
             else
-            {
                 leftRight -= 1;
-            }
-        }
 
         // Handle vertical movement (up and down)
         // Invert logic around the 90 degree pivot points (like lateral movement)

--- a/Brio/Game/Camera/VirtualCameraManager.cs
+++ b/Brio/Game/Camera/VirtualCameraManager.cs
@@ -270,10 +270,45 @@ public class VirtualCameraManager : IDisposable
             forwardBackward += 1;
 
         // Check for lateral movement
+        // Invert logic around the 90 degree pivot points
+        // (Similar to XIV's Default Camera)
         if(keyboardFrame->IsKeyDown(VirtualKey.A, true))
-            leftRight -= 1;
+        {
+            if(CurrentCamera.IsFreeCamera)
+            {
+                if(CurrentCamera.PivotRotation < BrioUtilities.DegreesToRadians(-90) || CurrentCamera.PivotRotation > BrioUtilities.DegreesToRadians(90))
+                {
+                    leftRight += 1;
+                }
+                else
+                {
+                    leftRight -= 1;
+                }
+            }
+            else
+            {
+                leftRight += 1;
+            }
+        }
+
         if(keyboardFrame->IsKeyDown(VirtualKey.D, true))
-            leftRight += 1;
+        {
+            if(CurrentCamera.IsFreeCamera)
+            {
+                if(CurrentCamera.PivotRotation < BrioUtilities.DegreesToRadians(-90) || CurrentCamera.PivotRotation > BrioUtilities.DegreesToRadians(90))
+                {
+                    leftRight -= 1;
+                }
+                else
+                {
+                    leftRight += 1;
+                }
+            }
+            else
+            {
+                leftRight -= 1;
+            }
+        }
 
         // Handle vertical movement (up and down)
         if(keyboardFrame->IsKeyDown(VirtualKey.E, true) || keyboardFrame->IsKeyDown(VirtualKey.SPACE, true))
@@ -331,7 +366,7 @@ public class VirtualCameraManager : IDisposable
         );
 
         // apply the Z axis rotation
-        var viewMatrix = Matrix4x4.Transform(matrix, Quaternion.CreateFromAxisAngle(Vector3.UnitZ, CurrentCamera.Rotation.Z));
+        var viewMatrix = Matrix4x4.Transform(matrix, Quaternion.CreateFromAxisAngle(Vector3.UnitZ, CurrentCamera.PivotRotation));
         return viewMatrix;
     }
 

--- a/Brio/Game/Camera/VirtualCameraManager.cs
+++ b/Brio/Game/Camera/VirtualCameraManager.cs
@@ -311,10 +311,23 @@ public class VirtualCameraManager : IDisposable
         }
 
         // Handle vertical movement (up and down)
+        // Invert logic around the 90 degree pivot points (like lateral movement)
         if(keyboardFrame->IsKeyDown(VirtualKey.E, true) || keyboardFrame->IsKeyDown(VirtualKey.SPACE, true))
-            upDown += 1;
+            if(CurrentCamera.IsFreeCamera)
+                if(CurrentCamera.PivotRotation < BrioUtilities.DegreesToRadians(-90) || CurrentCamera.PivotRotation > BrioUtilities.DegreesToRadians(90))
+                    upDown += 1;
+                else
+                    upDown -= 1;
+            else
+                upDown += 1;
         else if(keyboardFrame->IsKeyDown(VirtualKey.Q, true) || keyboardFrame->IsKeyDown(VirtualKey.CONTROL, true))
-            upDown += -1;
+            if(CurrentCamera.IsFreeCamera)
+                if(CurrentCamera.PivotRotation < BrioUtilities.DegreesToRadians(-90) || CurrentCamera.PivotRotation > BrioUtilities.DegreesToRadians(90))
+                    upDown -= 1;
+                else
+                    upDown += 1;
+            else
+                upDown -= 1;
 
         // Handle movement speed
         if(keyboardFrame->IsKeyDown(VirtualKey.SHIFT, true))

--- a/Brio/Game/Camera/VirtualCameraManager.cs
+++ b/Brio/Game/Camera/VirtualCameraManager.cs
@@ -318,7 +318,7 @@ public class VirtualCameraManager : IDisposable
         var upVector = Vector3.Cross(lookDirection, rightVector);
 
         // Create the view matrix
-        return new Matrix4x4
+        var matrix = new Matrix4x4
         (
             rightVector.X, upVector.X, lookDirection.X, 0.0f,
             rightVector.Y, upVector.Y, lookDirection.Y, 0.0f,
@@ -329,6 +329,10 @@ public class VirtualCameraManager : IDisposable
             (-CurrentCamera.Position.X * lookDirection.X) - (CurrentCamera.Position.Y * lookDirection.Y) - (CurrentCamera.Position.Z * lookDirection.Z),
             1f
         );
+
+        // apply the Z axis rotation
+        var viewMatrix = Matrix4x4.Transform(matrix, Quaternion.CreateFromAxisAngle(Vector3.UnitZ, CurrentCamera.Rotation.Z));
+        return viewMatrix;
     }
 
     private void OnGPoseStateChange(bool newState)

--- a/Brio/Game/Camera/VirtualCameraManager.cs
+++ b/Brio/Game/Camera/VirtualCameraManager.cs
@@ -312,7 +312,7 @@ public class VirtualCameraManager : IDisposable
 
         // Handle vertical movement (up and down)
         // Invert logic around the 90 degree pivot points (like lateral movement)
-        if(keyboardFrame->IsKeyDown(VirtualKey.E, true) || keyboardFrame->IsKeyDown(VirtualKey.SPACE, true))
+        if(keyboardFrame->IsKeyDown(VirtualKey.Q, true) || keyboardFrame->IsKeyDown(VirtualKey.CONTROL, true))
             if(CurrentCamera.IsFreeCamera)
                 if(CurrentCamera.PivotRotation < BrioUtilities.DegreesToRadians(-90) || CurrentCamera.PivotRotation > BrioUtilities.DegreesToRadians(90))
                     upDown += 1;
@@ -320,7 +320,7 @@ public class VirtualCameraManager : IDisposable
                     upDown -= 1;
             else
                 upDown += 1;
-        else if(keyboardFrame->IsKeyDown(VirtualKey.Q, true) || keyboardFrame->IsKeyDown(VirtualKey.CONTROL, true))
+        else if(keyboardFrame->IsKeyDown(VirtualKey.E, true) || keyboardFrame->IsKeyDown(VirtualKey.SPACE, true))
             if(CurrentCamera.IsFreeCamera)
                 if(CurrentCamera.PivotRotation < BrioUtilities.DegreesToRadians(-90) || CurrentCamera.PivotRotation > BrioUtilities.DegreesToRadians(90))
                     upDown -= 1;

--- a/Brio/UI/Controls/Editors/CameraEditor.cs
+++ b/Brio/UI/Controls/Editors/CameraEditor.cs
@@ -92,7 +92,7 @@ public static class CameraEditor
 
                     ImGui.SetNextItemWidth(width);
                     var rotation = camera.Rotation;
-                    if(ImBrio.DragFloat2V3("Rotation", ref rotation, -360, 360, "%.0f", true, ImGuiSliderFlags.AlwaysClamp))
+                    if(ImBrio.DragFloat2V3("Rotation", ref rotation, -360, 360, "%.3f", true, ImGuiSliderFlags.AlwaysClamp))
                         camera.Rotation = rotation;
                 }
 

--- a/Brio/UI/Controls/Editors/CameraEditor.cs
+++ b/Brio/UI/Controls/Editors/CameraEditor.cs
@@ -114,6 +114,11 @@ public static class CameraEditor
                     float pivot = camera.PivotRotation;
                     if(ImBrio.SliderAngle("##PivotRotation", ref pivot, -180, 180, "%.2f"))
                         camera.PivotRotation = pivot;
+                   
+                    ImGui.SameLine();
+
+                    if(ImBrio.FontIconButtonRight("resetPivotRotation", FontAwesomeIcon.Undo, 1f, "Reset Pivot", camera.PivotRotation != 0))
+                        camera.PivotRotation = 0;
                 }
 
                 ImGui.Separator();

--- a/Brio/UI/Controls/Editors/CameraEditor.cs
+++ b/Brio/UI/Controls/Editors/CameraEditor.cs
@@ -92,7 +92,7 @@ public static class CameraEditor
 
                     ImGui.SetNextItemWidth(width);
                     var rotation = camera.Rotation;
-                    if(ImGui.DragFloat3("Rotation", ref rotation, 0.001f))
+                    if(ImBrio.DragFloat2V3("Rotation", ref rotation, -360, 360, "%.0f", true, ImGuiSliderFlags.AlwaysClamp))
                         camera.Rotation = rotation;
                 }
 

--- a/Brio/UI/Controls/Editors/CameraEditor.cs
+++ b/Brio/UI/Controls/Editors/CameraEditor.cs
@@ -92,7 +92,7 @@ public static class CameraEditor
 
                     ImGui.SetNextItemWidth(width);
                     var rotation = camera.Rotation;
-                    if(ImBrio.DragFloat2V3("Rotation", ref rotation, -360, 360, "%.3f", true, ImGuiSliderFlags.AlwaysClamp))
+                    if(ImBrio.DragFloat2V3("Pan", ref rotation, -360, 360, "%.3f", true, ImGuiSliderFlags.AlwaysClamp))
                         camera.Rotation = rotation;
                 }
 

--- a/Brio/UI/Controls/Editors/CameraEditor.cs
+++ b/Brio/UI/Controls/Editors/CameraEditor.cs
@@ -106,6 +106,16 @@ public static class CameraEditor
                         camera.FoV = fov;
                 }
 
+                {
+                    ImBrio.Icon(FontAwesomeIcon.CameraRotate);
+
+                    ImGui.SameLine();
+
+                    float pivot = camera.PivotRotation;
+                    if(ImBrio.SliderAngle("##PivotRotation", ref pivot, -180, 180, "%.2f"))
+                        camera.PivotRotation = pivot;
+                }
+
                 ImGui.Separator();
 
                 {

--- a/Brio/UI/Controls/Stateless/ImBrio.Drag.cs
+++ b/Brio/UI/Controls/Stateless/ImBrio.Drag.cs
@@ -1,4 +1,5 @@
-﻿using Brio.Input;
+﻿using Brio.Core;
+using Brio.Input;
 using Brio.UI.Controls.Core;
 using Dalamud.Interface;
 using Dalamud.Interface.Utility.Raii;
@@ -225,6 +226,36 @@ public static partial class ImBrio
         }
 
         return (active, changed);
+    }
+
+    // Allows Vector3 to be used when Z is not needed in the UI
+    public static bool DragFloat2V3(string label, ref Vector3 value, float min, float max, string format, bool degrees = false, ImGuiSliderFlags flags = ImGuiSliderFlags.None, float step = 1.0f)
+    {
+        Vector2 vector2;
+        bool changed = false;
+
+        if(degrees)
+        {
+            // Convert to degrees
+            vector2 = new Vector2(BrioUtilities.RadiansToDegrees(-value.X), BrioUtilities.RadiansToDegrees(-value.Y));
+            changed = ImGui.DragFloat2(label, ref vector2, step, min, max, format, flags);
+            if(changed)
+            {
+                value.X = BrioUtilities.DegreesToRadians(-vector2.X);
+                value.Y = BrioUtilities.DegreesToRadians(-vector2.Y);
+            }
+        }
+        else
+        {
+            vector2 = new Vector2(value.X, value.Y);
+            changed = ImGui.DragFloat2(label, ref vector2, step, min, max, format, flags);
+            if(changed)
+            {
+                value.X = vector2.X;
+                value.Y = vector2.Y;
+            }
+        }
+        return changed;
     }
 }
 


### PR DESCRIPTION
This PR changes the following things:
1. Logic for camera deletion (exiting GPose or deleting cameras).
2. Adds the ability to rotate Free Cams via Pivot.
   > Pivot via XIV GPose Menu should work now.
3. Inverts logic on A, D, Q, Space, E, Ctrl keys for Free Cam movements.
4. Adds a new DragFloat2V3 element for use of Vector3 values where Z is not needed.
5. Changes the values of Rotation to be in degrees than Radians.