### PR TITLE
Handle parenting PartialSkeletons with multiple roots

### DIFF
--- a/Brio/Game/Posing/Skeletons/PartialSkeleton.cs
+++ b/Brio/Game/Posing/Skeletons/PartialSkeleton.cs
@@ -16,9 +16,7 @@ public unsafe class PartialSkeleton(Skeleton skeleton, int id)
 
     private readonly Dictionary<int, Bone> _bones = [];
 
-    public Bone? ParentBone { get; set; }
-
-    public Bone RootBone { get; set; } = null!;
+    public List<Bone> RootBones { get; set; } = [];
 
     public IReadOnlyDictionary<int, Bone> Bones => _bones;
 

--- a/Brio/Game/Posing/Skeletons/Skeleton.cs
+++ b/Brio/Game/Posing/Skeletons/Skeleton.cs
@@ -103,9 +103,8 @@ public class Skeleton : IDisposable
                     // Single-root partials are mapped by connected bone indices
                     var parentBone = Partials[0].GetOrCreateBone(partial->ConnectedParentBoneIndex);
                     var bone = newPartial.GetOrCreateBone(partial->ConnectedBoneIndex);
-
+                
                     bone.Parent = parentBone;
-                    parentBone.Children.Add(bone);
                     if(!parentBone.Children.Contains(bone))
                         parentBone.Children.Add(bone);
                 }
@@ -114,8 +113,8 @@ public class Skeleton : IDisposable
                     // Multi-root partials are mapped through their names
                     foreach(Bone bone in newPartial.RootBones)
                     {
-                        var parentBone = GetFirstVisibleBone(bone.Name);
-                        if(parentBone != null && bone != parentBone)
+                        var parentBone = Partials[0].GetBone(bone.Name);
+                        if(parentBone != null)
                         {
                             bone.Parent = parentBone;
                             if(!parentBone.Children.Contains(bone))

--- a/Brio/Game/Posing/Skeletons/Skeleton.cs
+++ b/Brio/Game/Posing/Skeletons/Skeleton.cs
@@ -78,11 +78,11 @@ public class Skeleton : IDisposable
                             {
                                 RootPartial = newPartial;
                                 RootBone = bone;
-                                bone.IsPartialRoot = true;
                                 bone.IsSkeletonRoot = true;
                             }
 
-                            newPartial.RootBone = bone;
+                            bone.IsPartialRoot = true;
+                            newPartial.RootBones.Add(bone);
                         }
                         else
                         {
@@ -98,16 +98,30 @@ public class Skeleton : IDisposable
 
             if(partialIdx != 0)
             {
-                if(partial->ConnectedBoneIndex >= 0 && partial->ConnectedParentBoneIndex >= 0)
+                if(newPartial.RootBones.Count == 1)
                 {
-                    var parent = Partials[0].GetOrCreateBone(partial->ConnectedParentBoneIndex);
-                    var child = newPartial.GetOrCreateBone(partial->ConnectedBoneIndex);
-                    child.IsPartialRoot = true;
-                    newPartial.ParentBone = parent;
-                    newPartial.RootBone = child;
+                    // Single-root partials are mapped by connected bone indices
+                    var parentBone = Partials[0].GetOrCreateBone(partial->ConnectedParentBoneIndex);
+                    var bone = newPartial.GetOrCreateBone(partial->ConnectedBoneIndex);
 
-                    parent.Children.Add(child);
-                    child.Parent = parent;
+                    bone.Parent = parentBone;
+                    parentBone.Children.Add(bone);
+                    if(!parentBone.Children.Contains(bone))
+                        parentBone.Children.Add(bone);
+                }
+                else
+                {
+                    // Multi-root partials are mapped through their names
+                    foreach(Bone bone in newPartial.RootBones)
+                    {
+                        var parentBone = GetFirstVisibleBone(bone.Name);
+                        if(parentBone != null && bone != parentBone)
+                        {
+                            bone.Parent = parentBone;
+                            if(!parentBone.Children.Contains(bone))
+                                parentBone.Children.Add(bone);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix for issue #38 and #176, seems to have to do with multi-root partial skeletons.

Implementation was inspired on how Ktisis does it, they did the heavy lifting in figuring out what is possible with what Havok has mapped, https://github.com/ktisis-tools/Ktisis/pull/139.

The assumptions for multi-root partial skeletons are that:
1. All bones with no parents are roots.
2. Their roots always link to the root partial skeleton
3. Their roots share names with the bones in the root partial skeleton.

It works for #38, but I do not know of any other multi-root partial skeletons I can test with.
