### PR TITLE
fix: move `RotationAsVector3` to CreateCamera function

### DIFF
--- a/Brio/Game/Camera/VirtualCamera.cs
+++ b/Brio/Game/Camera/VirtualCamera.cs
@@ -193,7 +193,6 @@ public unsafe partial class VirtualCamera
     {
         if(Position == Vector3.Zero)
             Position = RealPosition;
-        Rotation = RotationAsVector3;
         IsFreeCamera = true;
     }
 }

--- a/Brio/Game/Camera/VirtualCameraManager.cs
+++ b/Brio/Game/Camera/VirtualCameraManager.cs
@@ -56,11 +56,14 @@ public class VirtualCameraManager : IDisposable
     {
         if(_entityManager.TryGetEntity("cameras", out var ent))
         {
+            var oldCam = CurrentCamera;
             CurrentCamera?.DeactivateCamera();
-
+         
             int cameraId = _nextCameraId + 1;
 
             var camEnt = ActivatorUtilities.CreateInstance<CameraEntity>(_serviceProvider, cameraId, cameraType);
+            bool lastCameraIsFreeCam = oldCam?.IsFreeCamera ?? false;
+
             _entityManager.AttachEntity(camEnt, ent);
 
             if(virtualCamera is null)
@@ -72,6 +75,13 @@ public class VirtualCameraManager : IDisposable
                         camEnt.VirtualCamera.FreeCamValues.MouseSensitivity = DefaultMouseSensitivity;
                         camEnt.VirtualCamera.IsFreeCamera = true;
                         camEnt.VirtualCamera.ToFreeCam();
+
+                        // preserve the rotation from a BrioCamera if switching to a free cam
+                        if(!lastCameraIsFreeCam && oldCam is not null)
+                        {
+                            camEnt.VirtualCamera.Rotation = oldCam.RotationAsVector3;
+                        }
+
                         camEnt.VirtualCamera.ActivateCamera();
                         camEnt.VirtualCamera.DeactivateCamera();
                         _createdCameras.Add(cameraId, camEnt);


### PR DESCRIPTION
During 0.5.X betas and 0.6 currently, cloning Free Cameras makes them lose their rotation from the original camera. Turns out, the code that should apply the rotation from a BrioCam applies to both BrioCams and FreeCams which is unintended. Fix moves the rotation code to the Create Camera function and does checks to make sure it ONLY applies if the last selected camera is a BrioCamera to "preserve" BrioCamera rotation.