### PR TITLE
chore: brio camera positions to free cam positions

### DIFF
--- a/Brio/Game/Camera/BrioCamera.cs
+++ b/Brio/Game/Camera/BrioCamera.cs
@@ -36,74 +36,74 @@ public struct BrioCamera
 
     [FieldOffset(0x218)] public Vector2 Collide;
 
-    // Converts Brio Camera Angle and Pan Vector2s to Vector3 for Free Camera Rotation
-    // using Cubic Polynomials and Quadratic Equations
+    // Converts Brio Camera Angle and Pan Vector2s to a single Vector3 for Free Camera use
     private readonly Vector3 ConvertBrioCameraToXIVCamera()
-    { 
-        const float cubicACoefficient = 0.3083f;
-        const float cubicBCoefficient = -3.5417f;
-        const float cubicCCoefiicient = 14.5646f;
-        const float cubicDCoefficient = -24.6688f;
+    {
+        // Used for calculating rotation Y offset based on zoom level
+        // A lot of math calculation was done to get these values so don't
+        // touch them unless you know what you're doing.
+        const float RECIPROCAL_A_VALUE = 0.73f;
+        const float RECIPROCAL_B_VALUE = 15.742f;
 
-        const float quadraticACoefficient = -67.7f;
-        const float quadraticBCoefficient = 72.45f;
-
-        const float CONSTANT_X_OFFSET = 57.3f;
-
-        // Calculate offset based on Zoom level
-        // Yes.. this affects every calculation below
-        // This will be used as the C coefficient
-        float panYOffset = (float)((cubicACoefficient * Math.Pow(2.5, 3)) +
-                           (cubicBCoefficient * Math.Pow(2.5, 2)) +
-                           (cubicCCoefiicient * 2.5) +
-                           cubicDCoefficient);
-
-        Brio.Log.Verbose($"Zoom: {Zoom}, PanYOffset: {panYOffset}");
-
-        Vector3 rotation;
-        rotation.X = 0f;
-
-        float newXDegrees;
-        if (Angle.X == Pan.X)
+        // 1. Get approximate offset from zoom
+        // Use reciprocal of zoom to get rotation offset for Y axis
+        float currentCameraZoom;
+        if(Distance == 0)
         {
-            newXDegrees = 0f;
-        } else
-        {
-            newXDegrees = CONSTANT_X_OFFSET * (Angle.X - Pan.X);
-        }
-
-        float newYDegrees;
-        if((Angle.Y + Pan.Y < -2f) || (Angle.Y + Pan.Y > 2f))
-        {
-            // cap the angle and pan as beyond is position changes
-            // cap A at 1 (multiplication), B at 2 (addition)
-            if(Angle.Y + Pan.Y > 2f)
-            {
-                newYDegrees = (quadraticACoefficient * 1f) + (quadraticBCoefficient * 2f) + panYOffset; 
-            }
-            else
-            {
-                newYDegrees = (quadraticACoefficient * -1f) + (quadraticBCoefficient * -2f) + panYOffset;
-            }
+            Brio.Log.Warning("Distance is zero. Camera might be borked. Defaulting to 2.5f.");
+            currentCameraZoom = 2.5f; // Default for Brio camera
         }
         else
         {
-            newYDegrees = (quadraticACoefficient * (Angle.Y * Pan.Y)) + (quadraticBCoefficient * (Angle.Y + Pan.Y)) + panYOffset;
+            currentCameraZoom = Distance;
         }
-        newYDegrees = -newYDegrees; // Invert for XIV Camera
 
-        // convert to radians
-        float newXRadians = newXDegrees * MathHelpers.DegreesToRadians;
-        float newYRadians = newYDegrees * MathHelpers.DegreesToRadians;
+        // 2. Setup constants for rotation changes on Pan and Angle axis'
+        // Same as 1, don't touch unless you know what you're doing.
+        float ROT_Y_CHANGE_FROM_PAN_Y = ((0.878f * currentCameraZoom) + 51.805f) * MathHelpers.DegreesToRadians;
+        const float ROT_Y_CHANGE_FROM_ANGLE_Y = 51.1f * MathHelpers.DegreesToRadians;
+        const float ROT_X_CHANGE_FROM_PAN_X = 57.3f * MathHelpers.DegreesToRadians;
+        const float ROT_X_CHANGE_FROM_ANGLE_X = 57.33f * MathHelpers.DegreesToRadians;
 
-        rotation.X = newXRadians;
-        rotation.Y = newYRadians;
-        rotation.Z = Roll;
+        // 3. Offset Rotation Y based on zoom level after calculating pan and angle values
+        float rotationYOffset = (RECIPROCAL_A_VALUE - (RECIPROCAL_B_VALUE / currentCameraZoom)) * MathHelpers.DegreesToRadians;
+        rotationYOffset = -rotationYOffset; // Invert Y rotation to match rotation later on
+
+        // 4. Calculate rotation angles (degrees)
+        float rotX =
+            (ROT_X_CHANGE_FROM_PAN_X * Pan.X)
+            - (ROT_X_CHANGE_FROM_ANGLE_X * Angle.X);
+        rotX = -rotX; // Invert X rotation to match Free Camera
+
+        // 4.1 Setup exponent for Pan.Y to make it less sensitive at lower values
+        const float PAN_Y_EXPONENT_INTERCEPT = 1.501f;
+        const float PAN_Y_EXPONENT_SLOPE = -0.6f;
+        float panY = Math.Clamp(Pan.Y, -1f, 1f);
+        float effectivePanYExponent = PAN_Y_EXPONENT_INTERCEPT + (PAN_Y_EXPONENT_SLOPE * panY);
+
+        // 4.2 Calculate rotY with exponent applied to Pan.Y
+        float rotY =
+            (ROT_Y_CHANGE_FROM_PAN_Y * MathF.Pow(Pan.Y, effectivePanYExponent))
+            + (ROT_Y_CHANGE_FROM_ANGLE_Y * Angle.Y);
+        rotY = -rotY; // Invert Y rotation to match Free Camera
+
+        Brio.Log.Debug($"rotY: {rotY * MathHelpers.RadiansToDegrees}");
+
+        if (rotY == 0f)
+        {
+            // apply offset for Y if no other Y rotation is applied
+            Brio.Log.Debug("rotY returned 0, applying offset as rotation.Y");
+            rotY = rotationYOffset;
+        }
+
+        // 5. Convert Rotation to Quaternion Euler
+        Vector3 rotation;
+        rotation = new Vector3(rotX, rotY, Roll);
 
         return rotation;
     }
 
-    public readonly Vector3 RotationAsVector3 => ConvertBrioCameraToXIVCamera(); //new(Angle.X - Pan.X, -Angle.Y - Pan.Y, Roll);
+    public readonly Vector3 RotationAsVector3 => ConvertBrioCameraToXIVCamera();
 
     public readonly Quaternion CalculateDirectionAsQuaternion()
         => (new Vector3(-(Angle.Y + Pan.Y), ((Angle.X + MathF.PI) % MathF.Tau) - Pan.X, 0.0f)


### PR DESCRIPTION
Discussed in DM, but for those who wanna know, this basically reworks the logic of perserving a Brio Camera's Pan and Offset and translates it (more approximately) to Free Camera logic. This will partially angle cameras a bit above or below that of the Brio camera still but not by a large degree.