### PR TITLE
Disable unused `ImBrioText` service

### DIFF
--- a/Brio/Brio.cs
+++ b/Brio/Brio.cs
@@ -204,7 +204,7 @@ public class Brio : IDalamudPlugin
         serviceCollection.AddSingleton<CameraWindow>();
         serviceCollection.AddSingleton<PosingGraphicalWindow>();
         serviceCollection.AddSingleton<LightWindow>();
-        serviceCollection.AddSingleton<ImBrioText>();
+        // serviceCollection.AddSingleton<ImBrioText>();
 
         return serviceCollection;
     }


### PR DESCRIPTION
as discussed on discord
Disables loading the `ImBrioText` service for now as it is unused but consumes 300MB for VRAM for the font.