### PR TITLE
chore: use `IObjectTable` for LocalPlayer instead of IClientState 

### DIFF
--- a/Brio/Capabilities/Debug/DebugCapability.cs
+++ b/Brio/Capabilities/Debug/DebugCapability.cs
@@ -21,11 +21,11 @@ public unsafe class DebugCapability : Capability
 
     public bool IsPosing => _ktisisIPC.IsPosing;
 
-    public DebugCapability(IClientState clientState, Entity parent, GPoseService gPoseService, KtisisService ktisisIPC) : base(parent)
+    public DebugCapability(IClientState clientState, IObjectTable objectTable, Entity parent, GPoseService gPoseService, KtisisService ktisisIPC) : base(parent)
     {
         _gPoseService = gPoseService;
         _ktisisIPC = ktisisIPC;
-        Widget = new DebugWidget(this, clientState);
+        Widget = new DebugWidget(this, clientState, objectTable);
     }
 
     public void EnterGPose()

--- a/Brio/Core/MultiValueDictionary.cs
+++ b/Brio/Core/MultiValueDictionary.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Brio.Core;
 
-public class MultiValueDictionary<TKey, TValue> where TKey : notnull
+public class  MultiValueDictionary<TKey, TValue> where TKey : notnull
 {
     private readonly Dictionary<TKey, List<TValue>> _underlyingDictionary = [];
 

--- a/Brio/Game/Actor/ActorSpawnService.cs
+++ b/Brio/Game/Actor/ActorSpawnService.cs
@@ -75,7 +75,7 @@ public class ActorSpawnService : IDisposable
     {
         outCharacter = null;
 
-        var localPlayer = _clientState.LocalPlayer;
+        var localPlayer = _objectTable.LocalPlayer;
         if(localPlayer != null)
         {
             if(CloneCharacter(localPlayer, out outCharacter, flags, disableSpawnCompanion: disableSpawnCompanion))

--- a/Brio/Game/Core/DalamudService.cs
+++ b/Brio/Game/Core/DalamudService.cs
@@ -55,7 +55,7 @@ public class DalamudService : IDisposable
             IsInCutscene = false;
         }
 
-        var localPlayer = _clientState.LocalPlayer;
+        var localPlayer = _objectTable.LocalPlayer;
         if(localPlayer != null)
         {
             _classJobId = localPlayer.ClassJob.RowId;
@@ -75,12 +75,12 @@ public class DalamudService : IDisposable
 
     public uint GetHomeWorldId()
     {
-        return _clientState.LocalPlayer?.HomeWorld.RowId ?? 0;
+        return _objectTable.LocalPlayer?.HomeWorld.RowId ?? 0;
     }
 
     public bool GetIsPlayerPresent()
     {
-        return _clientState.LocalPlayer != null && _clientState.LocalPlayer.IsValid();
+        return _objectTable.LocalPlayer != null && _objectTable.LocalPlayer.IsValid();
     }
 
     public async Task<bool> GetIsPlayerPresentAsync()
@@ -90,7 +90,7 @@ public class DalamudService : IDisposable
 
     public string GetPlayerName()
     {
-        return _clientState.LocalPlayer?.Name.ToString() ?? "--";
+        return _objectTable.LocalPlayer?.Name.ToString() ?? "--";
     }
 
     public bool IsObjectPresent(IGameObject? obj)
@@ -114,7 +114,7 @@ public class DalamudService : IDisposable
     }
     public IPlayerCharacter GetPlayerCharacter()
     {
-        return _clientState.LocalPlayer!;
+        return _objectTable.LocalPlayer!;
     }
 
     public ICharacter? GetGposeCharacterFromObjectTableByName(string name, bool onlyGposeCharacters = false)

--- a/Brio/UI/Widgets/Debug/DebugWidget.cs
+++ b/Brio/UI/Widgets/Debug/DebugWidget.cs
@@ -9,7 +9,7 @@ using Dalamud.Plugin.Services;
 
 namespace Brio.UI.Widgets.Debug;
 
-public class DebugWidget(DebugCapability capability, IClientState _clientState) : Widget<DebugCapability>(capability)
+public class DebugWidget(DebugCapability capability, IClientState _clientState, IObjectTable _objectTable) : Widget<DebugCapability>(capability)
 {
     public override string HeaderName => "Debug";
 
@@ -86,8 +86,8 @@ public class DebugWidget(DebugCapability capability, IClientState _clientState) 
 
         ImGui.Text($"MapId - {_clientState.MapId}");
         ImGui.Text($"TerritoryType - {_clientState.TerritoryType}");
-        ImGui.Text($"CurrentWorld - {_clientState.LocalPlayer?.CurrentWorld.Value.Name}");
-        ImGui.Text($"HomeWorld - {_clientState.LocalPlayer?.HomeWorld.Value.Name}");
+        ImGui.Text($"CurrentWorld - {_objectTable.LocalPlayer?.CurrentWorld.Value.Name}");
+        ImGui.Text($"HomeWorld - {_objectTable.LocalPlayer?.HomeWorld.Value.Name}");
 
         ImGui.Text(io.Framerate.ToString("F2") + " FPS");
     }


### PR DESCRIPTION
As per API14 docs, `IClientState.LocalPlayer` is deprecated and suggested to use `IObjectTable.LocalPlayer`. This just changes or adds alongside `IClientState`, a `IObjectTable` class.