### PR TITLE
proof-of-concept IPC posing fixes

### DIFF
--- a/Brio/Game/Posing/ModelTransformService.cs
+++ b/Brio/Game/Posing/ModelTransformService.cs
@@ -16,7 +16,7 @@ namespace Brio.Game.Posing;
 public unsafe class ModelTransformService : IDisposable
 {
     public delegate void SetPositionDelegate(StructsGameObject* gameObject, float x, float y, float z);
-    private readonly Hook<SetPositionDelegate> _setPositionHook = null!;
+    public readonly Hook<SetPositionDelegate> _setPositionHook = null!;
 
     private readonly EntityManager _entityManager;
     private readonly GPoseService _gPoseService;

--- a/Brio/Game/Posing/SkeletonService.cs
+++ b/Brio/Game/Posing/SkeletonService.cs
@@ -27,11 +27,12 @@ public unsafe class SkeletonService : IDisposable
     public event SkeletonUpdateEvent? SkeletonUpdateStart;
     public event SkeletonUpdateEvent? SkeletonUpdateEnd;
 
-    private delegate nint UpdateBonePhysicsDelegate(nint a1);
-    private readonly Hook<UpdateBonePhysicsDelegate> _updateBonePhysicsHook = null!;
+    public delegate nint UpdateBonePhysicsDelegate(nint a1);
 
-    private delegate void FinalizeSkeletonsDelegate(nint a1);
-    private readonly Hook<FinalizeSkeletonsDelegate> _finalizeSkeletonsHook = null!;
+	public readonly Hook<UpdateBonePhysicsDelegate> _updateBonePhysicsHook = null!;
+
+    public delegate void FinalizeSkeletonsDelegate(nint a1);
+    public readonly Hook<FinalizeSkeletonsDelegate> _finalizeSkeletonsHook = null!;
 
     private readonly EntityManager _entityManager;
     private readonly ObjectMonitorService _monitorService;


### PR DESCRIPTION
resolves:
- brio bone manipulations causing infinitely spinning bones during ktisis posing mode (downstream from SkeletonService hooks)
- ktisis SyncModelSpaceDelegate issues in refreshing havok data for pose expressions (ModelTransformService hook)

caveats:
- relies on https://github.com/ktisis-tools/Ktisis/pull/266 (should be merged next release)
- unclear which areas of brio experience fallout from these hooks being disabled
- brio UX does not convey to the user which functionalities are temp disabled
- saw some crashing instability in testing when reopening gpose if the hooks weren't properly re-enabled, so this would likely want a failsafe (or safer startup behavior) - ditto for ensuring brio hooks are reenabled if ktisis fails to signal IsPosing stopped