### PR TITLE
Proper names for BNpcs, ENpcs, Companions, Mounts

### DIFF
--- a/Brio/Brio.cs
+++ b/Brio/Brio.cs
@@ -118,6 +118,7 @@ public class Brio : IDalamudPlugin
         serviceCollection.AddSingleton(dalamudServices.SigScanner);
         serviceCollection.AddSingleton(dalamudServices.ObjectTable);
         serviceCollection.AddSingleton(dalamudServices.DataManager);
+        serviceCollection.AddSingleton(dalamudServices.SeStringEvaluator);
         serviceCollection.AddSingleton(dalamudServices.CommandManager);
         serviceCollection.AddSingleton(dalamudServices.ToastGui);
         serviceCollection.AddSingleton(dalamudServices.TargetManager);

--- a/Brio/Capabilities/Actor/StatusEffectCapability.cs
+++ b/Brio/Capabilities/Actor/StatusEffectCapability.cs
@@ -50,6 +50,6 @@ public class StatusEffectCapability : ActorCapability
 
     public Status? GetStatus(uint rowId)
     {
-        return GameDataProvider.Instance.Statuses.TryGetValue(rowId, out var status) ? status : null;
+        return GameDataProvider.Instance.Statuses.TryGetRow(rowId, out var status) ? status : null;
     }
 }

--- a/Brio/Game/Actor/Extensions/StatusManagerExtensions.cs
+++ b/Brio/Game/Actor/Extensions/StatusManagerExtensions.cs
@@ -16,7 +16,7 @@ public static class StatusManagerExtensions
         {
             var effect = (ushort)sm.GetStatusId(i);
             if(effect != 0)
-                if(GameDataProvider.Instance.Statuses.TryGetValue(effect, out var status))
+                if(GameDataProvider.Instance.Statuses.TryGetRow(effect, out var status))
                     list.Add(status);
 
 

--- a/Brio/Game/Types/ActionTimelineTypes.cs
+++ b/Brio/Game/Types/ActionTimelineTypes.cs
@@ -10,7 +10,7 @@ public partial class ActionTimelineUnion : OneOfBase<BrioActionTimeline, None>
 {
     public static implicit operator ActionTimelineUnion(ActionTimelineId actionTimelineId)
     {
-        if(actionTimelineId.Id != 0 && GameDataProvider.Instance.ActionTimelines.TryGetValue(actionTimelineId.Id, out var timeline))
+        if(actionTimelineId.Id != 0 && GameDataProvider.Instance.ActionTimelines.TryGetRow(actionTimelineId.Id, out var timeline))
             return timeline;
 
         return new None();

--- a/Brio/Game/Types/DyeTypes.cs
+++ b/Brio/Game/Types/DyeTypes.cs
@@ -10,7 +10,7 @@ public partial class DyeUnion : OneOfBase<Stain, None>
 {
     public static implicit operator DyeUnion(DyeId dyeId)
     {
-        if(dyeId.Id != 0 && GameDataProvider.Instance.Stains.TryGetValue(dyeId.Id, out var dye))
+        if(dyeId.Id != 0 && GameDataProvider.Instance.Stains.TryGetRow(dyeId.Id, out var dye))
             return new DyeUnion(dye);
 
         return new None();

--- a/Brio/Game/Types/FacewearTypes.cs
+++ b/Brio/Game/Types/FacewearTypes.cs
@@ -10,7 +10,7 @@ public partial class FacewearUnion : OneOfBase<Glasses, None>
 {
     public static implicit operator FacewearUnion(FacewearId facewearId)
     {
-        if(facewearId.Id != 0 && GameDataProvider.Instance.Glasses.TryGetValue(facewearId.Id, out var glasses))
+        if(facewearId.Id != 0 && GameDataProvider.Instance.Glasses.TryGetRow(facewearId.Id, out var glasses))
             return new FacewearUnion(glasses);
 
         return new None();

--- a/Brio/Game/Types/WeatherTypes.cs
+++ b/Brio/Game/Types/WeatherTypes.cs
@@ -11,7 +11,7 @@ public partial class WeatherUnion : OneOfBase<Weather, None>
 {
     public static implicit operator WeatherUnion(WeatherId weatherId)
     {
-        if(weatherId.Id != 0 && GameDataProvider.Instance.Weathers.TryGetValue(weatherId.Id, out Weather weather))
+        if(weatherId.Id != 0 && GameDataProvider.Instance.Weathers.TryGetRow(weatherId.Id, out Weather weather))
             return weather;
 
         return new None();

--- a/Brio/Game/World/EnvironmentService.cs
+++ b/Brio/Game/World/EnvironmentService.cs
@@ -95,7 +95,7 @@ public class EnvironmentService : MediatorSubscriberBase
 
     private uint? _currentCachedTerritory;
 
-    public IEnumerable<Weather> AllWeatherCollection => _gameDataProvider.Weathers.Values;
+    public IEnumerable<Weather> AllWeatherCollection => _gameDataProvider.Weathers;
 
     private readonly IClientState _clientState;
     private readonly GameDataProvider _gameDataProvider;
@@ -183,7 +183,7 @@ public class EnvironmentService : MediatorSubscriberBase
             if(weatherId == 0)
                 continue;
 
-            if(!_gameDataProvider.Weathers.TryGetValue((uint)weatherId, out var weather))
+            if(!_gameDataProvider.Weathers.TryGetRow((uint)weatherId, out var weather))
                 continue;
 
             if(!_territoryWeatherTable.Any(x => x.RowId == weather.RowId))

--- a/Brio/Game/World/FestivalService.cs
+++ b/Brio/Game/World/FestivalService.cs
@@ -194,7 +194,7 @@ public unsafe class FestivalService : IDisposable
 
         var knownEntries = _resourceProvider.GetResourceDocument<List<FestivalFileEntry>>("Data.Festivals.json");
 
-        foreach(var (_, row) in gameDataProvider.Festivals)
+        foreach(var row in gameDataProvider.Festivals)
         {
             if(row.RowId == 0)
                 continue;

--- a/Brio/Resources/Extra/ModelDatabase.cs
+++ b/Brio/Resources/Extra/ModelDatabase.cs
@@ -18,8 +18,7 @@ public class ModelDatabase
         _modelsList = [];
 
         // From Game
-        var items = GameDataProvider.Instance.Items.Values;
-        foreach(var item in items)
+        foreach(var item in GameDataProvider.Instance.Items)
         {
             var slots = item.EquipSlotCategory.ValueNullable?.GetEquipSlots() ?? ActorEquipSlot.None;
             if(slots != ActorEquipSlot.None)

--- a/Brio/Resources/Extra/ModelDatabase.cs
+++ b/Brio/Resources/Extra/ModelDatabase.cs
@@ -12,13 +12,13 @@ public class ModelDatabase
     private readonly MultiValueDictionary<ulong, ModelInfo> _modelLookupTable;
     private readonly List<ModelInfo> _modelsList;
 
-    public ModelDatabase(ResourceProvider _resourceProvider)
+    public ModelDatabase(ResourceProvider _resourceProvider, GameDataProvider gameDataProvider)
     {
         _modelLookupTable = new();
         _modelsList = [];
 
         // From Game
-        foreach(var item in GameDataProvider.Instance.Items)
+        foreach(var item in gameDataProvider.Items)
         {
             var slots = item.EquipSlotCategory.ValueNullable?.GetEquipSlots() ?? ActorEquipSlot.None;
             if(slots != ActorEquipSlot.None)

--- a/Brio/Resources/GameDataProvider.cs
+++ b/Brio/Resources/GameDataProvider.cs
@@ -1,6 +1,8 @@
 ﻿using Brio.Game.Actor.Appearance;
 using Brio.Resources.Extra;
 using Brio.Resources.Sheets;
+using Dalamud.Game;
+using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Plugin.Services;
 using Lumina.Excel;
 using Lumina.Excel.Sheets;
@@ -12,6 +14,8 @@ public class GameDataProvider
     public static GameDataProvider Instance { get; private set; } = null!;
 
     public IDataManager DataManager { get; private set; }
+
+    public ISeStringEvaluator SeStringEvaluator { get; private set; }
 
     public readonly ExcelSheet<TerritoryType> TerritoryTypes;
     public readonly ExcelSheet<Weather> Weathers;
@@ -41,13 +45,13 @@ public class GameDataProvider
 
     public readonly HumanData HumanData;
 
-    public GameDataProvider(IDataManager dataManager, ResourceProvider _resourceProvider)
+    public GameDataProvider(IDataManager dataManager, ISeStringEvaluator seStringEvaluator, ResourceProvider _resourceProvider)
     {
         Instance = this;
 
         DataManager = dataManager;
 
-        ModelDatabase = new(_resourceProvider);
+        SeStringEvaluator = seStringEvaluator;
 
         TerritoryTypes = dataManager.GetExcelSheet<TerritoryType>();
 
@@ -96,5 +100,15 @@ public class GameDataProvider
         Glasses = dataManager.GetExcelSheet<Glasses>();
 
         HumanData = new HumanData(dataManager.GetFile("chara/xls/charamake/human.cmp")!.Data);
+
+        ModelDatabase = new(_resourceProvider, this);
     }
+
+    public string GetENpcName(uint eNpcNameId) => SeStringEvaluator.EvaluateObjStr(ObjectKind.EventNpc, eNpcNameId);
+
+    public string GetBNpcName(uint bNpcNameId) => SeStringEvaluator.EvaluateObjStr(ObjectKind.BattleNpc, bNpcNameId);
+
+    public string GetCompanionName(uint companionId) => SeStringEvaluator.EvaluateObjStr(ObjectKind.Companion, companionId);
+
+    public string GetMountName(uint mountId) => SeStringEvaluator.EvaluateActStr(ActionKind.Mount, mountId);
 }

--- a/Brio/Resources/GameDataProvider.cs
+++ b/Brio/Resources/GameDataProvider.cs
@@ -2,10 +2,8 @@
 using Brio.Resources.Extra;
 using Brio.Resources.Sheets;
 using Dalamud.Plugin.Services;
+using Lumina.Excel;
 using Lumina.Excel.Sheets;
-using System.Collections.Generic;
-using System.Linq;
-using Glasses = Lumina.Excel.Sheets.Glasses;
 
 namespace Brio.Resources;
 
@@ -15,29 +13,29 @@ public class GameDataProvider
 
     public IDataManager DataManager { get; private set; }
 
-    public readonly IReadOnlyDictionary<uint, TerritoryType> TerritoryTypes;
-    public readonly IReadOnlyDictionary<uint, Weather> Weathers;
-    public readonly IReadOnlyDictionary<uint, WeatherRate> WeatherRates;
-    public readonly IReadOnlyDictionary<uint, Companion> Companions;
-    public readonly IReadOnlyDictionary<uint, Ornament> Ornaments;
-    public readonly IReadOnlyDictionary<uint, Mount> Mounts;
-    public readonly IReadOnlyDictionary<uint, Festival> Festivals;
-    public readonly IReadOnlyDictionary<uint, Status> Statuses;
-    public readonly IReadOnlyDictionary<uint, BrioActionTimeline> ActionTimelines;
-    public readonly IReadOnlyDictionary<uint, Emote> Emotes;
-    public readonly IReadOnlyDictionary<uint, Action> Actions;
-    public readonly IReadOnlyDictionary<uint, ENpcBase> ENpcBases;
-    public readonly IReadOnlyDictionary<uint, ENpcResident> ENpcResidents;
-    public readonly IReadOnlyDictionary<uint, BNpcBase> BNpcBases;
-    public readonly IReadOnlyDictionary<uint, BNpcCustomize> BNpcCustomizations;
-    public readonly IReadOnlyDictionary<uint, BNpcName> BNpcNames;
-    public readonly IReadOnlyDictionary<uint, NpcEquip> NpcEquips;
-    public readonly IReadOnlyDictionary<uint, Stain> Stains;
-    public readonly IReadOnlyDictionary<uint, CharaMakeCustomize> CharaMakeCustomizations;
-    public readonly IReadOnlyDictionary<uint, BrioCharaMakeType> CharaMakeTypes;
-    public readonly IReadOnlyDictionary<uint, BrioHairMakeType> HairMakeTypes;
-    public readonly IReadOnlyDictionary<uint, Item> Items;
-    public readonly IReadOnlyDictionary<uint, Glasses> Glasses;
+    public readonly ExcelSheet<TerritoryType> TerritoryTypes;
+    public readonly ExcelSheet<Weather> Weathers;
+    public readonly ExcelSheet<WeatherRate> WeatherRates;
+    public readonly ExcelSheet<Companion> Companions;
+    public readonly ExcelSheet<Ornament> Ornaments;
+    public readonly ExcelSheet<Mount> Mounts;
+    public readonly ExcelSheet<Festival> Festivals;
+    public readonly ExcelSheet<Status> Statuses;
+    public readonly ExcelSheet<BrioActionTimeline> ActionTimelines;
+    public readonly ExcelSheet<Emote> Emotes;
+    public readonly ExcelSheet<Action> Actions;
+    public readonly ExcelSheet<ENpcBase> ENpcBases;
+    public readonly ExcelSheet<ENpcResident> ENpcResidents;
+    public readonly ExcelSheet<BNpcBase> BNpcBases;
+    public readonly ExcelSheet<BNpcCustomize> BNpcCustomizations;
+    public readonly ExcelSheet<BNpcName> BNpcNames;
+    public readonly ExcelSheet<NpcEquip> NpcEquips;
+    public readonly ExcelSheet<Stain> Stains;
+    public readonly ExcelSheet<CharaMakeCustomize> CharaMakeCustomizations;
+    public readonly ExcelSheet<BrioCharaMakeType> CharaMakeTypes;
+    public readonly ExcelSheet<BrioHairMakeType> HairMakeTypes;
+    public readonly ExcelSheet<Item> Items;
+    public readonly ExcelSheet<Glasses> Glasses;
 
     public readonly ModelDatabase ModelDatabase;
 
@@ -47,56 +45,56 @@ public class GameDataProvider
     {
         Instance = this;
 
-        TerritoryTypes = dataManager.GetExcelSheet<TerritoryType>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Weathers = dataManager.GetExcelSheet<Weather>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        WeatherRates = dataManager.GetExcelSheet<WeatherRate>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Companions = dataManager.GetExcelSheet<Companion>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Ornaments = dataManager.GetExcelSheet<Ornament>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Mounts = dataManager.GetExcelSheet<Mount>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Festivals = dataManager.GetExcelSheet<Festival>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Statuses = dataManager.GetExcelSheet<Status>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        ActionTimelines = dataManager.GetExcelSheet<BrioActionTimeline>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Emotes = dataManager.GetExcelSheet<Emote>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Actions = dataManager.GetExcelSheet<Action>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        ENpcBases = dataManager.GetExcelSheet<ENpcBase>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        ENpcResidents = dataManager.GetExcelSheet<ENpcResident>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        BNpcBases = dataManager.GetExcelSheet<BNpcBase>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        BNpcCustomizations = dataManager.GetExcelSheet<BNpcCustomize>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        BNpcNames = dataManager.GetExcelSheet<BNpcName>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        NpcEquips = dataManager.GetExcelSheet<NpcEquip>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Stains = dataManager.GetExcelSheet<Stain>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        CharaMakeCustomizations = dataManager.GetExcelSheet<CharaMakeCustomize>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        CharaMakeTypes = dataManager.GetExcelSheet<BrioCharaMakeType>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        HairMakeTypes = dataManager.GetExcelSheet<BrioHairMakeType>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Items = dataManager.GetExcelSheet<Item>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        Glasses = dataManager.GetExcelSheet<Glasses>()!.ToDictionary(x => x.RowId, x => x).AsReadOnly();
-
-        HumanData = new HumanData(dataManager.GetFile("chara/xls/charamake/human.cmp")!.Data);
+        DataManager = dataManager;
 
         ModelDatabase = new(_resourceProvider);
 
-        DataManager = dataManager;
+        TerritoryTypes = dataManager.GetExcelSheet<TerritoryType>();
+
+        Weathers = dataManager.GetExcelSheet<Weather>();
+
+        WeatherRates = dataManager.GetExcelSheet<WeatherRate>();
+
+        Companions = dataManager.GetExcelSheet<Companion>();
+
+        Ornaments = dataManager.GetExcelSheet<Ornament>();
+
+        Mounts = dataManager.GetExcelSheet<Mount>();
+
+        Festivals = dataManager.GetExcelSheet<Festival>();
+
+        Statuses = dataManager.GetExcelSheet<Status>();
+
+        ActionTimelines = dataManager.GetExcelSheet<BrioActionTimeline>();
+
+        Emotes = dataManager.GetExcelSheet<Emote>();
+
+        Actions = dataManager.GetExcelSheet<Action>();
+
+        ENpcBases = dataManager.GetExcelSheet<ENpcBase>();
+
+        ENpcResidents = dataManager.GetExcelSheet<ENpcResident>();
+
+        BNpcBases = dataManager.GetExcelSheet<BNpcBase>();
+
+        BNpcCustomizations = dataManager.GetExcelSheet<BNpcCustomize>();
+
+        BNpcNames = dataManager.GetExcelSheet<BNpcName>();
+
+        NpcEquips = dataManager.GetExcelSheet<NpcEquip>();
+
+        Stains = dataManager.GetExcelSheet<Stain>();
+
+        CharaMakeCustomizations = dataManager.GetExcelSheet<CharaMakeCustomize>();
+
+        CharaMakeTypes = dataManager.GetExcelSheet<BrioCharaMakeType>();
+
+        HairMakeTypes = dataManager.GetExcelSheet<BrioHairMakeType>();
+
+        Items = dataManager.GetExcelSheet<Item>();
+
+        Glasses = dataManager.GetExcelSheet<Glasses>();
+
+        HumanData = new HumanData(dataManager.GetFile("chara/xls/charamake/human.cmp")!.Data);
     }
 }

--- a/Brio/Services/DalamudPluginService.cs
+++ b/Brio/Services/DalamudPluginService.cs
@@ -13,6 +13,7 @@ public class DalamudPluginService
     [PluginService] public ISigScanner SigScanner { get; private set; } = null!;
     [PluginService] public IObjectTable ObjectTable { get; private set; } = null!;
     [PluginService] public IDataManager DataManager { get; private set; } = null!;
+    [PluginService] public ISeStringEvaluator SeStringEvaluator { get; private set; } = null!;
     [PluginService] public ICommandManager CommandManager { get; private set; } = null!;
     [PluginService] public IToastGui ToastGui { get; private set; } = null!;
     [PluginService] public ITargetManager TargetManager { get; private set; } = null!;

--- a/Brio/Services/Library/Sources/GameDataCompanionSource.cs
+++ b/Brio/Services/Library/Sources/GameDataCompanionSource.cs
@@ -18,7 +18,8 @@ public class GameDataCompanionSource : GameDataAppearanceSourceBase
         foreach(var companion in Lumina.Companions)
         {
             string rowName = $"Companion {companion.RowId}";
-            var entry = new GameDataAppearanceEntry(this, EntityManager, companion.RowId, companion.Singular.ToString() ?? rowName, companion.Icon, companion, $"{companion.RowId}");
+            var displayName = Lumina.GetCompanionName(companion.RowId);
+            var entry = new GameDataAppearanceEntry(this, EntityManager, companion.RowId, displayName, companion.Icon, companion, $"{companion.RowId}");
             entry.Tags.Add("Companion").WithAlias("Minion");
             entry.SourceInfo = rowName;
             Add(entry);

--- a/Brio/Services/Library/Sources/GameDataCompanionSource.cs
+++ b/Brio/Services/Library/Sources/GameDataCompanionSource.cs
@@ -15,7 +15,7 @@ public class GameDataCompanionSource : GameDataAppearanceSourceBase
 
     public override void Scan()
     {
-        foreach(var (_, companion) in Lumina.Companions)
+        foreach(var companion in Lumina.Companions)
         {
             string rowName = $"Companion {companion.RowId}";
             var entry = new GameDataAppearanceEntry(this, EntityManager, companion.RowId, companion.Singular.ToString() ?? rowName, companion.Icon, companion, $"{companion.RowId}");

--- a/Brio/Services/Library/Sources/GameDataMountSource.cs
+++ b/Brio/Services/Library/Sources/GameDataMountSource.cs
@@ -19,7 +19,7 @@ public class GameDataMountSource : GameDataAppearanceSourceBase
         {
             string rowName = $"Mount {mount.RowId}";
 
-            string name = mount.Singular.ToString();
+            string name = Lumina.GetMountName(mount.RowId);
             if(string.IsNullOrEmpty(name))
                 name = rowName;
 

--- a/Brio/Services/Library/Sources/GameDataMountSource.cs
+++ b/Brio/Services/Library/Sources/GameDataMountSource.cs
@@ -15,7 +15,7 @@ public class GameDataMountSource : GameDataAppearanceSourceBase
 
     public override void Scan()
     {
-        foreach(var (_, mount) in Lumina.Mounts)
+        foreach(var mount in Lumina.Mounts)
         {
             string rowName = $"Mount {mount.RowId}";
 

--- a/Brio/Services/Library/Sources/GameDataNpcSource.cs
+++ b/Brio/Services/Library/Sources/GameDataNpcSource.cs
@@ -16,7 +16,7 @@ public class GameDataNpcSource : GameDataAppearanceSourceBase
 
     public override void Scan()
     {
-        foreach(var (_, npc) in Lumina.BNpcBases)
+        foreach(var npc in Lumina.BNpcBases)
         {
             string name = $"B:{npc.RowId:D7}";
             string? displayName = ResolveName(name);
@@ -31,7 +31,7 @@ public class GameDataNpcSource : GameDataAppearanceSourceBase
             Add(entry);
         }
 
-        foreach(var (_, npc) in Lumina.ENpcBases)
+        foreach(var npc in Lumina.ENpcBases)
         {
             string name = $"E:{npc.RowId:D7}";
             string? displayName = null;
@@ -67,7 +67,7 @@ public class GameDataNpcSource : GameDataAppearanceSourceBase
         if(name.StartsWith("N:"))
         {
             var nameId = uint.Parse(name.Substring(2));
-            if(GameDataProvider.Instance.BNpcNames.TryGetValue(nameId, out var nameRef))
+            if(GameDataProvider.Instance.BNpcNames.TryGetRow(nameId, out var nameRef))
             {
                 if(!string.IsNullOrEmpty(nameRef.Singular.ToString()))
                 {

--- a/Brio/Services/Library/Sources/GameDataNpcSource.cs
+++ b/Brio/Services/Library/Sources/GameDataNpcSource.cs
@@ -34,14 +34,9 @@ public class GameDataNpcSource : GameDataAppearanceSourceBase
         foreach(var npc in Lumina.ENpcBases)
         {
             string name = $"E:{npc.RowId:D7}";
-            string? displayName = null;
+            var displayName = Lumina.GetENpcName(npc.RowId);
 
-            var resident = Lumina.ENpcResidents[npc.RowId];
-            if(!string.IsNullOrEmpty(resident.Singular.ToString()))
-            {
-                displayName = resident.Singular.ToString();
-            }
-            else
+            if(string.IsNullOrEmpty(displayName))
             {
                 displayName = ResolveName(name);
             }
@@ -57,7 +52,7 @@ public class GameDataNpcSource : GameDataAppearanceSourceBase
         }
     }
 
-    public static string? ResolveName(string name)
+    public string? ResolveName(string name)
     {
         var names = ResourceProvider.Instance.GetResourceDocument<IReadOnlyDictionary<string, string>>("Data.NpcNames.json");
 
@@ -67,12 +62,11 @@ public class GameDataNpcSource : GameDataAppearanceSourceBase
         if(name.StartsWith("N:"))
         {
             var nameId = uint.Parse(name.Substring(2));
-            if(GameDataProvider.Instance.BNpcNames.TryGetRow(nameId, out var nameRef))
+            var bNpcName = Lumina.GetBNpcName(nameId);
+
+            if(!string.IsNullOrEmpty(bNpcName))
             {
-                if(!string.IsNullOrEmpty(nameRef.Singular.ToString()))
-                {
-                    return nameRef.Singular.ToString();
-                }
+                return bNpcName;
             }
         }
 

--- a/Brio/Services/Library/Sources/GameDataOrnamentSource.cs
+++ b/Brio/Services/Library/Sources/GameDataOrnamentSource.cs
@@ -15,7 +15,7 @@ public class GameDataOrnamentSource : GameDataAppearanceSourceBase
 
     public override void Scan()
     {
-        foreach(var (_, ornament) in Lumina.Ornaments)
+        foreach(var ornament in Lumina.Ornaments)
         {
             string rowName = $"Ornament {ornament.RowId}";
             var entry = new GameDataAppearanceEntry(this, EntityManager, ornament.RowId, ornament.Singular.ToString() ?? rowName, ornament.Icon, ornament, $"{ornament.RowId}");

--- a/Brio/UI/Controls/Selectors/ActionTimelineSelector.cs
+++ b/Brio/UI/Controls/Selectors/ActionTimelineSelector.cs
@@ -112,7 +112,7 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
 
     protected override void PopulateList()
     {
-        foreach(var timeline in GameDataProvider.Instance.ActionTimelines.Values)
+        foreach(var timeline in GameDataProvider.Instance.ActionTimelines)
         {
             if(!string.IsNullOrEmpty(timeline.Key.ToString()))
                 AddItem(new ActionTimelineSelectorEntry(
@@ -128,14 +128,14 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
                     0));
         }
 
-        foreach(var emote in GameDataProvider.Instance.Emotes.Values)
+        foreach(var emote in GameDataProvider.Instance.Emotes)
         {
             BrioActionTimeline timeline;
             bool drawsWeapon = emote.DrawsWeapon;
             byte emoteCategory = (byte)emote.EmoteCategory.RowId;
 
             // Loop
-            if(emote.ActionTimeline[0].RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetValue(emote.ActionTimeline[0].RowId, out timeline))
+            if(emote.ActionTimeline[0].RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetRow(emote.ActionTimeline[0].RowId, out timeline))
             {
                 AddItem(new ActionTimelineSelectorEntry(
                     emote.Name.ToString(),
@@ -151,7 +151,7 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
             }
 
             // Intro
-            if(emote.ActionTimeline[1].RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetValue(emote.ActionTimeline[1].RowId, out timeline))
+            if(emote.ActionTimeline[1].RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetRow(emote.ActionTimeline[1].RowId, out timeline))
             {
                 AddItem(new ActionTimelineSelectorEntry(
                     emote.Name.ToString(),
@@ -167,7 +167,7 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
             }
 
             // Ground
-            if(emote.ActionTimeline[2].RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetValue(emote.ActionTimeline[2].RowId, out timeline))
+            if(emote.ActionTimeline[2].RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetRow(emote.ActionTimeline[2].RowId, out timeline))
             {
                 AddItem(new ActionTimelineSelectorEntry(
                     emote.Name.ToString(),
@@ -183,7 +183,7 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
             }
 
             // Chair
-            if(emote.ActionTimeline[3].RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetValue(emote.ActionTimeline[3].RowId, out timeline))
+            if(emote.ActionTimeline[3].RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetRow(emote.ActionTimeline[3].RowId, out timeline))
             {
                 AddItem(new ActionTimelineSelectorEntry(
                     emote.Name.ToString(),
@@ -199,7 +199,7 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
             }
 
             // Upper Body
-            if(emote.ActionTimeline[4].RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetValue(emote.ActionTimeline[4].RowId, out timeline))
+            if(emote.ActionTimeline[4].RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetRow(emote.ActionTimeline[4].RowId, out timeline))
             {
                 AddItem(new ActionTimelineSelectorEntry(
                     emote.Name.ToString(),
@@ -215,9 +215,9 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
             }
         }
 
-        foreach(var action in GameDataProvider.Instance.Actions.Values)
+        foreach(var action in GameDataProvider.Instance.Actions)
         {
-            if(action.AnimationEnd.RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetValue(action.AnimationEnd.RowId, out BrioActionTimeline timeline))
+            if(action.AnimationEnd.RowId != 0 && GameDataProvider.Instance.ActionTimelines.TryGetRow(action.AnimationEnd.RowId, out BrioActionTimeline timeline))
                 AddItem(new ActionTimelineSelectorEntry(
                     action.Name.ToString(),
                     (ushort)action.AnimationEnd.RowId,

--- a/Brio/UI/Controls/Selectors/CompanionSelector.cs
+++ b/Brio/UI/Controls/Selectors/CompanionSelector.cs
@@ -74,8 +74,8 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
             return false;
 
         var searchText = item.Match(
-            companion => $"{companion.Singular} {companion.Plural} {companion.RowId} {companion.Model.RowId}",
-            mount => $"{mount.Singular} {mount.Plural} {mount.RowId} {mount.ModelChara.RowId}",
+            companion => $"{GameDataProvider.Instance.GetCompanionName(companion.RowId)} {companion.Plural} {companion.RowId} {companion.Model.RowId}",
+            mount => $"{GameDataProvider.Instance.GetMountName(mount.RowId)} {mount.Plural} {mount.RowId} {mount.ModelChara.RowId}",
             ornament => $"{ornament.Singular} {ornament.Plural} {ornament.RowId} {ornament.Model}",
             none => "none"
         );
@@ -98,15 +98,15 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
 
         // Get name
         var textA = itemA.Match(
-            companion => companion.Singular.ToString(),
-            mount => mount.Singular.ToString(),
+            companion => GameDataProvider.Instance.GetCompanionName(companion.RowId),
+            mount => GameDataProvider.Instance.GetMountName(mount.RowId),
             ornament => ornament.Singular.ToString(),
             none => ""
         );
 
         var textB = itemB.Match(
-            companion => companion.Singular.ToString(),
-            mount => mount.Singular.ToString(),
+            companion => GameDataProvider.Instance.GetCompanionName(companion.RowId),
+            mount => GameDataProvider.Instance.GetMountName(mount.RowId),
             ornament => ornament.Singular.ToString(),
             none => ""
         );

--- a/Brio/UI/Controls/Selectors/CompanionSelector.cs
+++ b/Brio/UI/Controls/Selectors/CompanionSelector.cs
@@ -23,13 +23,13 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
 
     protected override void PopulateList()
     {
-        foreach(var companion in GameDataProvider.Instance.Companions.Values)
+        foreach(var companion in GameDataProvider.Instance.Companions)
             AddItem(companion);
 
-        foreach(var mount in GameDataProvider.Instance.Mounts.Values)
+        foreach(var mount in GameDataProvider.Instance.Mounts)
             AddItem(mount);
 
-        foreach(var ornament in GameDataProvider.Instance.Ornaments.Values)
+        foreach(var ornament in GameDataProvider.Instance.Ornaments)
             AddItem(ornament);
 
         AddItem(new None());

--- a/Brio/UI/Controls/Selectors/CompanionSelector.cs
+++ b/Brio/UI/Controls/Selectors/CompanionSelector.cs
@@ -1,9 +1,10 @@
-﻿using Brio.Game.Types;
+﻿using System.Numerics;
+using Brio.Game.Types;
 using Brio.Resources;
 using Brio.UI.Controls.Stateless;
 using Dalamud.Bindings.ImGui;
+using Lumina.Excel.Sheets;
 using OneOf.Types;
-using System.Numerics;
 
 namespace Brio.UI.Controls.Selectors;
 
@@ -74,8 +75,8 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
             return false;
 
         var searchText = item.Match(
-            companion => $"{GameDataProvider.Instance.GetCompanionName(companion.RowId)} {companion.Plural} {companion.RowId} {companion.Model.RowId}",
-            mount => $"{GameDataProvider.Instance.GetMountName(mount.RowId)} {mount.Plural} {mount.RowId} {mount.ModelChara.RowId}",
+            companion => $"{GetCompanionNameWithFallback(companion)} {companion.Plural} {companion.RowId} {companion.Model.RowId}",
+            mount => $"{GetMountNameWithFallback(mount)} {mount.Plural} {mount.RowId} {mount.ModelChara.RowId}",
             ornament => $"{ornament.Singular} {ornament.Plural} {ornament.RowId} {ornament.Model}",
             none => "none"
         );
@@ -98,15 +99,15 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
 
         // Get name
         var textA = itemA.Match(
-            companion => GameDataProvider.Instance.GetCompanionName(companion.RowId),
-            mount => GameDataProvider.Instance.GetMountName(mount.RowId),
+            companion => GetCompanionNameWithFallback(companion),
+            mount => GetMountNameWithFallback(mount),
             ornament => ornament.Singular.ToString(),
             none => ""
         );
 
         var textB = itemB.Match(
-            companion => GameDataProvider.Instance.GetCompanionName(companion.RowId),
-            mount => GameDataProvider.Instance.GetMountName(mount.RowId),
+            companion => GetCompanionNameWithFallback(companion),
+            mount => GetMountNameWithFallback(mount),
             ornament => ornament.Singular.ToString(),
             none => ""
         );
@@ -121,4 +122,7 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
         // Alphabetical
         return string.Compare(textA, textB, System.StringComparison.InvariantCultureIgnoreCase);
     }
+
+    private static string GetCompanionNameWithFallback(Companion companion) => GameDataProvider.Instance.GetCompanionName(companion.RowId) is { Length: not 0 } companionName ? companionName : $"Companion {companion.RowId}";
+    private static string GetMountNameWithFallback(Mount mount) => GameDataProvider.Instance.GetMountName(mount.RowId) is { Length: not 0 } mountName ? mountName : $"Mount {mount.RowId}";
 }

--- a/Brio/UI/Controls/Selectors/DyeSelector.cs
+++ b/Brio/UI/Controls/Selectors/DyeSelector.cs
@@ -18,7 +18,7 @@ public class DyeSelector(string id) : Selector<DyeUnion>(id)
 
     protected override void PopulateList()
     {
-        foreach(var stain in GameDataProvider.Instance.Stains.Values)
+        foreach(var stain in GameDataProvider.Instance.Stains)
             AddItem(stain);
 
         AddItem(new None());

--- a/Brio/UI/Controls/Selectors/FacewearSelector.cs
+++ b/Brio/UI/Controls/Selectors/FacewearSelector.cs
@@ -18,7 +18,7 @@ public class FacewearSelector(string id) : Selector<FacewearUnion>(id)
 
     protected override void PopulateList()
     {
-        foreach(var glasses in GameDataProvider.Instance.Glasses.Values)
+        foreach(var glasses in GameDataProvider.Instance.Glasses)
             AddItem(glasses);
 
         AddItem(new None());

--- a/Brio/UI/Controls/Selectors/NpcSelector.cs
+++ b/Brio/UI/Controls/Selectors/NpcSelector.cs
@@ -1,11 +1,11 @@
-﻿using Brio.Game.Types;
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Brio.Game.Types;
 using Brio.Resources;
 using Brio.UI.Controls.Stateless;
 using Dalamud.Bindings.ImGui;
 using Lumina.Excel.Sheets;
-using System;
-using System.Collections.Generic;
-using System.Numerics;
 using static Brio.UI.Controls.Selectors.NpcSelector;
 
 namespace Brio.UI.Controls.Selectors;
@@ -27,37 +27,37 @@ public class NpcSelector(string id) : Selector<NpcSelectorEntry>(id)
 
     protected override void PopulateList()
     {
-        foreach(var npc in GameDataProvider.Instance.BNpcBases)
+        var gameDataProvider = GameDataProvider.Instance;
+
+        foreach(var npc in gameDataProvider.BNpcBases)
         {
-            string name = $"B:{npc.RowId:D7}";
-            name = ResolveName(name);
-            AddItem(new NpcSelectorEntry(name, 0, npc));
+            var name = ResolveName($"B:{npc.RowId:D7}");
+            AddItem(new NpcSelectorEntry(name ?? $"BNpc {npc.RowId}", 0, npc));
         }
 
-        foreach(var npc in GameDataProvider.Instance.ENpcBases)
+        foreach(var npc in gameDataProvider.ENpcBases)
         {
-            string name = $"E:{npc.RowId:D7}";
+            var name = gameDataProvider.GetENpcName(npc.RowId);
 
-            var resident = GameDataProvider.Instance.ENpcResidents[npc.RowId];
+            if (string.IsNullOrEmpty(name))
+                name = ResolveName($"E:{npc.RowId:D7}");
 
-            if(!string.IsNullOrEmpty(resident.Singular.ToString()))
-                name = resident.Singular.ToString();
-
-            name = ResolveName(name);
-            AddItem(new NpcSelectorEntry(name, 0, npc));
+            AddItem(new NpcSelectorEntry(name ?? $"ENpc {npc.RowId}", 0, npc));
         }
 
-        foreach(var mount in GameDataProvider.Instance.Mounts)
+        foreach(var mount in gameDataProvider.Mounts)
         {
-            AddItem(new NpcSelectorEntry(mount.Singular.ToString() ?? $"Mount {mount.RowId}", mount.Icon, mount));
+            var name = GameDataProvider.Instance.GetMountName(mount.RowId);
+            AddItem(new NpcSelectorEntry(name ?? $"Mount {mount.RowId}", mount.Icon, mount));
         }
 
-        foreach(var companion in GameDataProvider.Instance.Companions)
+        foreach(var companion in gameDataProvider.Companions)
         {
-            AddItem(new NpcSelectorEntry(companion.Singular.ToString() ?? $"Companion {companion.RowId}", companion.Icon, companion));
+            var name = gameDataProvider.GetCompanionName(companion.RowId);
+            AddItem(new NpcSelectorEntry(name ?? $"Companion {companion.RowId}", companion.Icon, companion));
         }
 
-        foreach(var ornament in GameDataProvider.Instance.Ornaments)
+        foreach(var ornament in gameDataProvider.Ornaments)
         {
             AddItem(new NpcSelectorEntry(ornament.Singular.ToString() ?? $"Ornament {ornament.RowId}", ornament.Icon, ornament));
         }
@@ -73,9 +73,9 @@ public class NpcSelector(string id) : Selector<NpcSelectorEntry>(id)
         if(name.StartsWith("N:"))
         {
             var nameId = uint.Parse(name.Substring(2));
-            if(GameDataProvider.Instance.BNpcNames.TryGetRow(nameId, out var nameRef))
-                if(!string.IsNullOrEmpty(nameRef.Singular.ToString()))
-                    name = nameRef.Singular.ToString();
+            var bNpcName = GameDataProvider.Instance.GetBNpcName(nameId);
+            if(!string.IsNullOrEmpty(bNpcName))
+                name = bNpcName;
         }
 
         return name;

--- a/Brio/UI/Controls/Selectors/NpcSelector.cs
+++ b/Brio/UI/Controls/Selectors/NpcSelector.cs
@@ -27,14 +27,14 @@ public class NpcSelector(string id) : Selector<NpcSelectorEntry>(id)
 
     protected override void PopulateList()
     {
-        foreach(var (_, npc) in GameDataProvider.Instance.BNpcBases)
+        foreach(var npc in GameDataProvider.Instance.BNpcBases)
         {
             string name = $"B:{npc.RowId:D7}";
             name = ResolveName(name);
             AddItem(new NpcSelectorEntry(name, 0, npc));
         }
 
-        foreach(var (_, npc) in GameDataProvider.Instance.ENpcBases)
+        foreach(var npc in GameDataProvider.Instance.ENpcBases)
         {
             string name = $"E:{npc.RowId:D7}";
 
@@ -47,17 +47,17 @@ public class NpcSelector(string id) : Selector<NpcSelectorEntry>(id)
             AddItem(new NpcSelectorEntry(name, 0, npc));
         }
 
-        foreach(var (_, mount) in GameDataProvider.Instance.Mounts)
+        foreach(var mount in GameDataProvider.Instance.Mounts)
         {
             AddItem(new NpcSelectorEntry(mount.Singular.ToString() ?? $"Mount {mount.RowId}", mount.Icon, mount));
         }
 
-        foreach(var (_, companion) in GameDataProvider.Instance.Companions)
+        foreach(var companion in GameDataProvider.Instance.Companions)
         {
             AddItem(new NpcSelectorEntry(companion.Singular.ToString() ?? $"Companion {companion.RowId}", companion.Icon, companion));
         }
 
-        foreach(var (_, ornament) in GameDataProvider.Instance.Ornaments)
+        foreach(var ornament in GameDataProvider.Instance.Ornaments)
         {
             AddItem(new NpcSelectorEntry(ornament.Singular.ToString() ?? $"Ornament {ornament.RowId}", ornament.Icon, ornament));
         }
@@ -73,7 +73,7 @@ public class NpcSelector(string id) : Selector<NpcSelectorEntry>(id)
         if(name.StartsWith("N:"))
         {
             var nameId = uint.Parse(name.Substring(2));
-            if(GameDataProvider.Instance.BNpcNames.TryGetValue(nameId, out var nameRef))
+            if(GameDataProvider.Instance.BNpcNames.TryGetRow(nameId, out var nameRef))
                 if(!string.IsNullOrEmpty(nameRef.Singular.ToString()))
                     name = nameRef.Singular.ToString();
         }

--- a/Brio/UI/Controls/Selectors/NpcSelector.cs
+++ b/Brio/UI/Controls/Selectors/NpcSelector.cs
@@ -32,34 +32,54 @@ public class NpcSelector(string id) : Selector<NpcSelectorEntry>(id)
         foreach(var npc in gameDataProvider.BNpcBases)
         {
             var name = ResolveName($"B:{npc.RowId:D7}");
-            AddItem(new NpcSelectorEntry(name ?? $"BNpc {npc.RowId}", 0, npc));
+
+            if(string.IsNullOrEmpty(name))
+                name = $"BNpc {npc.RowId}";
+
+            AddItem(new NpcSelectorEntry(name, 0, npc));
         }
 
         foreach(var npc in gameDataProvider.ENpcBases)
         {
             var name = gameDataProvider.GetENpcName(npc.RowId);
 
-            if (string.IsNullOrEmpty(name))
+            if(string.IsNullOrEmpty(name))
                 name = ResolveName($"E:{npc.RowId:D7}");
 
-            AddItem(new NpcSelectorEntry(name ?? $"ENpc {npc.RowId}", 0, npc));
+            if(string.IsNullOrEmpty(name))
+                name = $"ENpc {npc.RowId}";
+
+            AddItem(new NpcSelectorEntry(name, 0, npc));
         }
 
         foreach(var mount in gameDataProvider.Mounts)
         {
             var name = GameDataProvider.Instance.GetMountName(mount.RowId);
-            AddItem(new NpcSelectorEntry(name ?? $"Mount {mount.RowId}", mount.Icon, mount));
+
+            if(string.IsNullOrEmpty(name))
+                name = $"Mount {mount.RowId}";
+
+            AddItem(new NpcSelectorEntry(name, mount.Icon, mount));
         }
 
         foreach(var companion in gameDataProvider.Companions)
         {
             var name = gameDataProvider.GetCompanionName(companion.RowId);
-            AddItem(new NpcSelectorEntry(name ?? $"Companion {companion.RowId}", companion.Icon, companion));
+
+            if(string.IsNullOrEmpty(name))
+                name = $"Companion {companion.RowId}";
+
+            AddItem(new NpcSelectorEntry(name, companion.Icon, companion));
         }
 
         foreach(var ornament in gameDataProvider.Ornaments)
         {
-            AddItem(new NpcSelectorEntry(ornament.Singular.ToString() ?? $"Ornament {ornament.RowId}", ornament.Icon, ornament));
+            var name = ornament.Singular.ToString();
+
+            if(string.IsNullOrEmpty(name))
+                name = $"Ornament {ornament.RowId}";
+
+            AddItem(new NpcSelectorEntry(name, ornament.Icon, ornament));
         }
     }
 

--- a/Brio/UI/Controls/Selectors/StatusEffectSelector.cs
+++ b/Brio/UI/Controls/Selectors/StatusEffectSelector.cs
@@ -24,7 +24,7 @@ public class StatusEffectSelector(string id) : Selector<StatusEffectSelectorHold
 
     protected override void PopulateList()
     {
-        foreach(var item in GameDataProvider.Instance.Statuses.Values)
+        foreach(var item in GameDataProvider.Instance.Statuses)
         {
             AddItem(new StatusEffectSelectorHolder { Status = item });
         }

--- a/Brio/UI/Controls/Selectors/WeatherSelector.cs
+++ b/Brio/UI/Controls/Selectors/WeatherSelector.cs
@@ -23,7 +23,7 @@ public class WeatherSelector(string id) : Selector<WeatherUnion>(id)
 
     protected override void PopulateList()
     {
-        foreach(var weather in GameDataProvider.Instance.Weathers.Values)
+        foreach(var weather in GameDataProvider.Instance.Weathers)
             AddItem(weather);
     }
 

--- a/Brio/UI/Controls/Stateless/ImBrio.Companions.cs
+++ b/Brio/UI/Controls/Stateless/ImBrio.Companions.cs
@@ -1,6 +1,7 @@
-﻿using Brio.Game.Types;
+﻿using System.Numerics;
+using Brio.Game.Types;
+using Brio.Resources;
 using Dalamud.Bindings.ImGui;
-using System.Numerics;
 
 namespace Brio.UI.Controls.Stateless;
 
@@ -9,8 +10,8 @@ public static partial class ImBrio
     public static bool BorderedGameIcon(string id, CompanionRowUnion union, bool showText = true, ImGuiButtonFlags flags = ImGuiButtonFlags.MouseButtonLeft, Vector2? size = null)
     {
         var (description, icon) = union.Match(
-           companion => ($"{companion.Singular}\n{companion.RowId}\nModel: {companion.Model.RowId}", companion.Icon),
-           mount => ($"{mount.Singular}\n{mount.RowId}\nModel: {mount.ModelChara.RowId}", mount.Icon),
+           companion => ($"{GameDataProvider.Instance.GetCompanionName(companion.RowId)}\n{companion.RowId}\nModel: {companion.Model.RowId}", companion.Icon),
+           mount => ($"{GameDataProvider.Instance.GetMountName(mount.RowId)}\n{mount.RowId}\nModel: {mount.ModelChara.RowId}", mount.Icon),
            ornament => ($"{ornament.Singular}\n{ornament.RowId}\nModel: {ornament.Model}", ornament.Icon),
            none => ("None", (uint)0)
        );


### PR DESCRIPTION
In the German client, the game uses noun placeholders for BNpcs, ENpcs and Companions, so they looks like this:

<img width="1034" height="414" alt="Screenshot - Before" src="https://github.com/user-attachments/assets/554a9dc3-7bba-4461-aa5a-68b11c986fc6" />

Using the SeStringEvaluator in Dalamud, this is properly formatted to the singular name:

<img width="1053" height="289" alt="Screenshot - After" src="https://github.com/user-attachments/assets/2bf71fda-2a61-44d8-81ff-dea70a63cf40" />

In the English client, the game saves singular names in lower case, so it can insert them into sentences.
Using the SeStringEvaliator we can also capitalize them properly. Example for mounts:

<img width="353" height="383" alt="Mounts" src="https://github.com/user-attachments/assets/1ccc282f-c1ea-4a30-b6ae-7890435bf90f" />

For convenience and centralization, I added functions to GameDataProvider that resolve those names.

I've also allowed myself to replace the IReadOnlyDictionaries in GameDataProvider with ExcelSheets. They already use FrozenDictionaries internally to get the offset to the row, so there is really no need to cache those. :)

I hope this is fine. 🙏
I don't know the codebase very well, so if there are any issues or things I should change, don't hesitate to tell me. 😅