### PR TITLE
Resolve names in GameDataProvider

### DIFF
--- a/Brio/Resources/GameDataProvider.cs
+++ b/Brio/Resources/GameDataProvider.cs
@@ -1,4 +1,5 @@
-﻿using Brio.Game.Actor.Appearance;
+﻿using System.Collections.Generic;
+using Brio.Game.Actor.Appearance;
 using Brio.Resources.Extra;
 using Brio.Resources.Sheets;
 using Dalamud.Game;
@@ -13,9 +14,11 @@ public class GameDataProvider
 {
     public static GameDataProvider Instance { get; private set; } = null!;
 
-    public IDataManager DataManager { get; private set; }
+    public IDataManager DataManager { get; }
 
-    public ISeStringEvaluator SeStringEvaluator { get; private set; }
+    public ISeStringEvaluator SeStringEvaluator { get; }
+
+    public ResourceProvider ResourceProvider { get; }
 
     public readonly ExcelSheet<TerritoryType> TerritoryTypes;
     public readonly ExcelSheet<Weather> Weathers;
@@ -45,13 +48,15 @@ public class GameDataProvider
 
     public readonly HumanData HumanData;
 
-    public GameDataProvider(IDataManager dataManager, ISeStringEvaluator seStringEvaluator, ResourceProvider _resourceProvider)
+    public GameDataProvider(IDataManager dataManager, ISeStringEvaluator seStringEvaluator, ResourceProvider resourceProvider)
     {
         Instance = this;
 
         DataManager = dataManager;
 
         SeStringEvaluator = seStringEvaluator;
+
+        ResourceProvider = resourceProvider;
 
         TerritoryTypes = dataManager.GetExcelSheet<TerritoryType>();
 
@@ -101,14 +106,35 @@ public class GameDataProvider
 
         HumanData = new HumanData(dataManager.GetFile("chara/xls/charamake/human.cmp")!.Data);
 
-        ModelDatabase = new(_resourceProvider, this);
+        ModelDatabase = new(resourceProvider, this);
     }
 
-    public string GetENpcName(uint eNpcNameId) => SeStringEvaluator.EvaluateObjStr(ObjectKind.EventNpc, eNpcNameId);
+    public string GetENpcName(uint eNpcNameId) => SeStringEvaluator.EvaluateObjStr(ObjectKind.EventNpc, eNpcNameId) is { Length: not 0 } name ? name : ResolveName($"E:{eNpcNameId:D7}") ?? $"ENpc {eNpcNameId}";
 
-    public string GetBNpcName(uint bNpcNameId) => SeStringEvaluator.EvaluateObjStr(ObjectKind.BattleNpc, bNpcNameId);
+    public string GetBNpcName(uint bNpcNameId) => SeStringEvaluator.EvaluateObjStr(ObjectKind.BattleNpc, bNpcNameId) is { Length: not 0 } name ? name : ResolveName($"B:{bNpcNameId:D7}") ?? $"BNpc {bNpcNameId}";
 
-    public string GetCompanionName(uint companionId) => SeStringEvaluator.EvaluateObjStr(ObjectKind.Companion, companionId);
+    public string GetCompanionName(uint companionId) => SeStringEvaluator.EvaluateObjStr(ObjectKind.Companion, companionId) is { Length: not 0 } name ? name : $"Companion {companionId}";
 
-    public string GetMountName(uint mountId) => SeStringEvaluator.EvaluateActStr(ActionKind.Mount, mountId);
+    public string GetMountName(uint mountId) => SeStringEvaluator.EvaluateActStr(ActionKind.Mount, mountId) is { Length: not 0 } name ? name : $"Mount {mountId}";
+
+    public string? ResolveName(string name)
+    {
+        var names = ResourceProvider.GetResourceDocument<IReadOnlyDictionary<string, string>>("Data.NpcNames.json");
+
+        if(names.TryGetValue(name, out var nameOverride))
+            name = nameOverride;
+
+        if(name.StartsWith("N:"))
+        {
+            var nameId = uint.Parse(name.Substring(2));
+            var bNpcName = GetBNpcName(nameId);
+
+            if(!string.IsNullOrEmpty(bNpcName))
+            {
+                return bNpcName;
+            }
+        }
+
+        return null;
+    }
 }

--- a/Brio/Resources/GameDataProvider.cs
+++ b/Brio/Resources/GameDataProvider.cs
@@ -121,6 +121,8 @@ public class GameDataProvider
 
     public string GetMountName(uint mountId) => SeStringEvaluator.EvaluateActStr(ActionKind.Mount, mountId) is { Length: not 0 } name ? name : $"Mount {mountId}";
 
+    public string GetOrnamentName(uint ornamentId) => SeStringEvaluator.EvaluateActStr(ActionKind.Ornament, ornamentId) is { Length: not 0 } name ? name : $"Ornament {ornamentId}";
+
     public string? ResolveName(string name)
     {
         if(NpcNames.TryGetValue(name, out var nameOverride))

--- a/Brio/Resources/GameDataProvider.cs
+++ b/Brio/Resources/GameDataProvider.cs
@@ -48,6 +48,8 @@ public class GameDataProvider
 
     public readonly HumanData HumanData;
 
+    public readonly IReadOnlyDictionary<string, string> NpcNames;
+
     public GameDataProvider(IDataManager dataManager, ISeStringEvaluator seStringEvaluator, ResourceProvider resourceProvider)
     {
         Instance = this;
@@ -106,6 +108,8 @@ public class GameDataProvider
 
         HumanData = new HumanData(dataManager.GetFile("chara/xls/charamake/human.cmp")!.Data);
 
+        NpcNames = ResourceProvider.GetResourceDocument<IReadOnlyDictionary<string, string>>("Data.NpcNames.json");
+
         ModelDatabase = new(resourceProvider, this);
     }
 
@@ -119,9 +123,7 @@ public class GameDataProvider
 
     public string? ResolveName(string name)
     {
-        var names = ResourceProvider.GetResourceDocument<IReadOnlyDictionary<string, string>>("Data.NpcNames.json");
-
-        if(names.TryGetValue(name, out var nameOverride))
+        if(NpcNames.TryGetValue(name, out var nameOverride))
             name = nameOverride;
 
         if(name.StartsWith("N:"))

--- a/Brio/Services/Library/Sources/GameDataCompanionSource.cs
+++ b/Brio/Services/Library/Sources/GameDataCompanionSource.cs
@@ -18,9 +18,13 @@ public class GameDataCompanionSource : GameDataAppearanceSourceBase
         foreach(var companion in Lumina.Companions)
         {
             string rowName = $"Companion {companion.RowId}";
-            var displayName = Lumina.GetCompanionName(companion.RowId);
-            var entry = new GameDataAppearanceEntry(this, EntityManager, companion.RowId, displayName, companion.Icon, companion, $"{companion.RowId}");
+            var name = Lumina.GetCompanionName(companion.RowId);
+            var entry = new GameDataAppearanceEntry(this, EntityManager, companion.RowId, name, companion.Icon, companion, $"{companion.RowId}");
             entry.Tags.Add("Companion").WithAlias("Minion");
+
+            if(name != rowName)
+                entry.Tags.Add("Named");
+
             entry.SourceInfo = rowName;
             Add(entry);
         }

--- a/Brio/Services/Library/Sources/GameDataMountSource.cs
+++ b/Brio/Services/Library/Sources/GameDataMountSource.cs
@@ -18,10 +18,7 @@ public class GameDataMountSource : GameDataAppearanceSourceBase
         foreach(var mount in Lumina.Mounts)
         {
             string rowName = $"Mount {mount.RowId}";
-
             string name = Lumina.GetMountName(mount.RowId);
-            if(string.IsNullOrEmpty(name))
-                name = rowName;
 
             var entry = new GameDataAppearanceEntry(this, EntityManager, mount.RowId, name, mount.Icon, mount, $"{mount.RowId}");
             entry.Tags.Add("Mount");

--- a/Brio/Services/Library/Sources/GameDataNpcSource.cs
+++ b/Brio/Services/Library/Sources/GameDataNpcSource.cs
@@ -1,6 +1,5 @@
 ﻿using Brio.Entities;
 using Brio.Resources;
-using System.Collections.Generic;
 
 namespace Brio.Library.Sources;
 
@@ -18,14 +17,13 @@ public class GameDataNpcSource : GameDataAppearanceSourceBase
     {
         foreach(var npc in Lumina.BNpcBases)
         {
-            string name = $"B:{npc.RowId:D7}";
-            string? displayName = ResolveName(name);
-            var entry = new GameDataAppearanceEntry(this, EntityManager, npc.RowId, displayName ?? name, 0, npc, $"B{npc.RowId}");
+            string rowName = $"B:{npc.RowId:D7}";
+            string? displayName = Lumina.GetBNpcName(npc.RowId);
+            var entry = new GameDataAppearanceEntry(this, EntityManager, npc.RowId, displayName, 0, npc, $"B{npc.RowId}");
             entry.SourceInfo = $"BNpc {npc.RowId}";
             entry.Tags.Add("NPC");
 
-
-            if(!string.IsNullOrEmpty(displayName))
+            if(!string.IsNullOrEmpty(displayName) && displayName != rowName)
                 entry.Tags.Add("Named");
 
             Add(entry);
@@ -33,44 +31,17 @@ public class GameDataNpcSource : GameDataAppearanceSourceBase
 
         foreach(var npc in Lumina.ENpcBases)
         {
-            string name = $"E:{npc.RowId:D7}";
+            string rowName = $"E:{npc.RowId:D7}";
             var displayName = Lumina.GetENpcName(npc.RowId);
-
-            if(string.IsNullOrEmpty(displayName))
-            {
-                displayName = ResolveName(name);
-            }
-
-            var entry = new GameDataAppearanceEntry(this, EntityManager, npc.RowId, displayName ?? name, 0, npc, $"E{npc.RowId}");
+            var entry = new GameDataAppearanceEntry(this, EntityManager, npc.RowId, displayName ?? rowName, 0, npc, $"E{npc.RowId}");
             entry.SourceInfo = $"ENpc {npc.RowId}";
             entry.Tags.Add("NPC");
 
-            if(!string.IsNullOrEmpty(displayName))
+            if(!string.IsNullOrEmpty(displayName) && displayName != rowName)
                 entry.Tags.Add("Named");
 
             Add(entry);
         }
-    }
-
-    public string? ResolveName(string name)
-    {
-        var names = ResourceProvider.Instance.GetResourceDocument<IReadOnlyDictionary<string, string>>("Data.NpcNames.json");
-
-        if(names.TryGetValue(name, out var nameOverride))
-            name = nameOverride;
-
-        if(name.StartsWith("N:"))
-        {
-            var nameId = uint.Parse(name.Substring(2));
-            var bNpcName = Lumina.GetBNpcName(nameId);
-
-            if(!string.IsNullOrEmpty(bNpcName))
-            {
-                return bNpcName;
-            }
-        }
-
-        return null;
     }
 
     protected override string GetpublicId()

--- a/Brio/Services/Library/Sources/GameDataNpcSource.cs
+++ b/Brio/Services/Library/Sources/GameDataNpcSource.cs
@@ -23,7 +23,7 @@ public class GameDataNpcSource : GameDataAppearanceSourceBase
             entry.SourceInfo = $"BNpc {npc.RowId}";
             entry.Tags.Add("NPC");
 
-            if(!string.IsNullOrEmpty(displayName) && displayName != rowName)
+            if(!string.IsNullOrEmpty(displayName) && displayName != rowName && displayName != $"BNpc {npc.RowId}")
                 entry.Tags.Add("Named");
 
             Add(entry);
@@ -37,7 +37,7 @@ public class GameDataNpcSource : GameDataAppearanceSourceBase
             entry.SourceInfo = $"ENpc {npc.RowId}";
             entry.Tags.Add("NPC");
 
-            if(!string.IsNullOrEmpty(displayName) && displayName != rowName)
+            if(!string.IsNullOrEmpty(displayName) && displayName != rowName && displayName != $"ENpc {npc.RowId}")
                 entry.Tags.Add("Named");
 
             Add(entry);

--- a/Brio/Services/Library/Sources/GameDataOrnamentSource.cs
+++ b/Brio/Services/Library/Sources/GameDataOrnamentSource.cs
@@ -18,8 +18,13 @@ public class GameDataOrnamentSource : GameDataAppearanceSourceBase
         foreach(var ornament in Lumina.Ornaments)
         {
             string rowName = $"Ornament {ornament.RowId}";
-            var entry = new GameDataAppearanceEntry(this, EntityManager, ornament.RowId, ornament.Singular.ToString() ?? rowName, ornament.Icon, ornament, $"{ornament.RowId}");
+            var name = GameDataProvider.Instance.GetOrnamentName(ornament.RowId);
+            var entry = new GameDataAppearanceEntry(this, EntityManager, ornament.RowId, name, ornament.Icon, ornament, $"{ornament.RowId}");
             entry.Tags.Add("Ornament").WithAlias("Fashion Accessory");
+
+            if(name != rowName)
+                entry.Tags.Add("Named");
+
             entry.SourceInfo = rowName;
             Add(entry);
         }

--- a/Brio/UI/Controls/Selectors/CompanionSelector.cs
+++ b/Brio/UI/Controls/Selectors/CompanionSelector.cs
@@ -3,7 +3,6 @@ using Brio.Game.Types;
 using Brio.Resources;
 using Brio.UI.Controls.Stateless;
 using Dalamud.Bindings.ImGui;
-using Lumina.Excel.Sheets;
 using OneOf.Types;
 
 namespace Brio.UI.Controls.Selectors;
@@ -75,8 +74,8 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
             return false;
 
         var searchText = item.Match(
-            companion => $"{GetCompanionNameWithFallback(companion)} {companion.Plural} {companion.RowId} {companion.Model.RowId}",
-            mount => $"{GetMountNameWithFallback(mount)} {mount.Plural} {mount.RowId} {mount.ModelChara.RowId}",
+            companion => $"{GameDataProvider.Instance.GetCompanionName(companion.RowId)} {companion.Plural} {companion.RowId} {companion.Model.RowId}",
+            mount => $"{GameDataProvider.Instance.GetMountName(mount.RowId)} {mount.Plural} {mount.RowId} {mount.ModelChara.RowId}",
             ornament => $"{ornament.Singular} {ornament.Plural} {ornament.RowId} {ornament.Model}",
             none => "none"
         );
@@ -99,15 +98,15 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
 
         // Get name
         var textA = itemA.Match(
-            companion => GetCompanionNameWithFallback(companion),
-            mount => GetMountNameWithFallback(mount),
+            companion => GameDataProvider.Instance.GetCompanionName(companion.RowId),
+            mount => GameDataProvider.Instance.GetMountName(mount.RowId),
             ornament => ornament.Singular.ToString(),
             none => ""
         );
 
         var textB = itemB.Match(
-            companion => GetCompanionNameWithFallback(companion),
-            mount => GetMountNameWithFallback(mount),
+            companion => GameDataProvider.Instance.GetCompanionName(companion.RowId),
+            mount => GameDataProvider.Instance.GetMountName(mount.RowId),
             ornament => ornament.Singular.ToString(),
             none => ""
         );
@@ -122,7 +121,4 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
         // Alphabetical
         return string.Compare(textA, textB, System.StringComparison.InvariantCultureIgnoreCase);
     }
-
-    private static string GetCompanionNameWithFallback(Companion companion) => GameDataProvider.Instance.GetCompanionName(companion.RowId) is { Length: not 0 } companionName ? companionName : $"Companion {companion.RowId}";
-    private static string GetMountNameWithFallback(Mount mount) => GameDataProvider.Instance.GetMountName(mount.RowId) is { Length: not 0 } mountName ? mountName : $"Mount {mount.RowId}";
 }

--- a/Brio/UI/Controls/Selectors/CompanionSelector.cs
+++ b/Brio/UI/Controls/Selectors/CompanionSelector.cs
@@ -76,7 +76,7 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
         var searchText = item.Match(
             companion => $"{GameDataProvider.Instance.GetCompanionName(companion.RowId)} {companion.Plural} {companion.RowId} {companion.Model.RowId}",
             mount => $"{GameDataProvider.Instance.GetMountName(mount.RowId)} {mount.Plural} {mount.RowId} {mount.ModelChara.RowId}",
-            ornament => $"{ornament.Singular} {ornament.Plural} {ornament.RowId} {ornament.Model}",
+            ornament => $"{GameDataProvider.Instance.GetOrnamentName(ornament.RowId)} {ornament.Plural} {ornament.RowId} {ornament.Model}",
             none => "none"
         );
 
@@ -100,14 +100,14 @@ public class CompanionSelector(string id) : Selector<CompanionRowUnion>(id)
         var textA = itemA.Match(
             companion => GameDataProvider.Instance.GetCompanionName(companion.RowId),
             mount => GameDataProvider.Instance.GetMountName(mount.RowId),
-            ornament => ornament.Singular.ToString(),
+            ornament => GameDataProvider.Instance.GetOrnamentName(ornament.RowId),
             none => ""
         );
 
         var textB = itemB.Match(
             companion => GameDataProvider.Instance.GetCompanionName(companion.RowId),
             mount => GameDataProvider.Instance.GetMountName(mount.RowId),
-            ornament => ornament.Singular.ToString(),
+            ornament => GameDataProvider.Instance.GetOrnamentName(ornament.RowId),
             none => ""
         );
 

--- a/Brio/UI/Controls/Selectors/NpcSelector.cs
+++ b/Brio/UI/Controls/Selectors/NpcSelector.cs
@@ -31,44 +31,25 @@ public class NpcSelector(string id) : Selector<NpcSelectorEntry>(id)
 
         foreach(var npc in gameDataProvider.BNpcBases)
         {
-            var name = ResolveName($"B:{npc.RowId:D7}");
-
-            if(string.IsNullOrEmpty(name))
-                name = $"BNpc {npc.RowId}";
-
+            var name = gameDataProvider.GetBNpcName(npc.RowId);
             AddItem(new NpcSelectorEntry(name, 0, npc));
         }
 
         foreach(var npc in gameDataProvider.ENpcBases)
         {
             var name = gameDataProvider.GetENpcName(npc.RowId);
-
-            if(string.IsNullOrEmpty(name))
-                name = ResolveName($"E:{npc.RowId:D7}");
-
-            if(string.IsNullOrEmpty(name))
-                name = $"ENpc {npc.RowId}";
-
             AddItem(new NpcSelectorEntry(name, 0, npc));
         }
 
         foreach(var mount in gameDataProvider.Mounts)
         {
-            var name = GameDataProvider.Instance.GetMountName(mount.RowId);
-
-            if(string.IsNullOrEmpty(name))
-                name = $"Mount {mount.RowId}";
-
+            var name = gameDataProvider.GetMountName(mount.RowId);
             AddItem(new NpcSelectorEntry(name, mount.Icon, mount));
         }
 
         foreach(var companion in gameDataProvider.Companions)
         {
             var name = gameDataProvider.GetCompanionName(companion.RowId);
-
-            if(string.IsNullOrEmpty(name))
-                name = $"Companion {companion.RowId}";
-
             AddItem(new NpcSelectorEntry(name, companion.Icon, companion));
         }
 
@@ -81,24 +62,6 @@ public class NpcSelector(string id) : Selector<NpcSelectorEntry>(id)
 
             AddItem(new NpcSelectorEntry(name, ornament.Icon, ornament));
         }
-    }
-
-    private static string ResolveName(string name)
-    {
-        var names = ResourceProvider.Instance.GetResourceDocument<IReadOnlyDictionary<string, string>>("Data.NpcNames.json");
-
-        if(names.TryGetValue(name, out var nameOverride))
-            name = nameOverride;
-
-        if(name.StartsWith("N:"))
-        {
-            var nameId = uint.Parse(name.Substring(2));
-            var bNpcName = GameDataProvider.Instance.GetBNpcName(nameId);
-            if(!string.IsNullOrEmpty(bNpcName))
-                name = bNpcName;
-        }
-
-        return name;
     }
 
     protected override void DrawOptions()

--- a/Brio/UI/Controls/Selectors/NpcSelector.cs
+++ b/Brio/UI/Controls/Selectors/NpcSelector.cs
@@ -55,11 +55,7 @@ public class NpcSelector(string id) : Selector<NpcSelectorEntry>(id)
 
         foreach(var ornament in gameDataProvider.Ornaments)
         {
-            var name = ornament.Singular.ToString();
-
-            if(string.IsNullOrEmpty(name))
-                name = $"Ornament {ornament.RowId}";
-
+            var name = GameDataProvider.Instance.GetOrnamentName(ornament.RowId);
             AddItem(new NpcSelectorEntry(name, ornament.Icon, ornament));
         }
     }

--- a/Brio/UI/Controls/Stateless/ImBrio.Companions.cs
+++ b/Brio/UI/Controls/Stateless/ImBrio.Companions.cs
@@ -12,7 +12,7 @@ public static partial class ImBrio
         var (description, icon) = union.Match(
            companion => ($"{GameDataProvider.Instance.GetCompanionName(companion.RowId)}\n{companion.RowId}\nModel: {companion.Model.RowId}", companion.Icon),
            mount => ($"{GameDataProvider.Instance.GetMountName(mount.RowId)}\n{mount.RowId}\nModel: {mount.ModelChara.RowId}", mount.Icon),
-           ornament => ($"{ornament.Singular}\n{ornament.RowId}\nModel: {ornament.Model}", ornament.Icon),
+           ornament => ($"{GameDataProvider.Instance.GetOrnamentName(ornament.RowId)}\n{ornament.RowId}\nModel: {ornament.Model}", ornament.Icon),
            none => ("None", (uint)0)
        );
 

--- a/Brio/UI/Windows/LibraryWindow.cs
+++ b/Brio/UI/Windows/LibraryWindow.cs
@@ -715,7 +715,7 @@ public class LibraryWindow : Window
             {
                 try
                 {
-                    using(var child = ImRaii.Child("library_search_input", new(searchBarWidth, searchBarHeight), false, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse))
+                    using(var child = ImRaii.Child("library_search_input_child", new(searchBarWidth, searchBarHeight), false, ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoScrollWithMouse))
                     {
 
                         if(child.Success)
@@ -840,7 +840,7 @@ public class LibraryWindow : Window
 
             // clear the search input buffer
             data.BufTextLen = 0;
-            data.BufSize = 0;
+            data.BufSize = 256 + 1;
             data.CursorPos = 0;
             data.SelectionStart = 0;
             data.SelectionEnd = 0;


### PR DESCRIPTION
Sorry, I should've drafted the other PR while I was fixing something.
I noticed the Companion selector was lacking names now due to the null check on emtpy strings.
I've reworked this a little bit to do all the fallbacks and npc name resolving in the GameDataProvider instead.
Sorry again!