### PR TITLE
Update FileSource.cs to fix Tags not being written to pose files

### DIFF
--- a/Brio/Services/Library/Sources/FileSource.cs
+++ b/Brio/Services/Library/Sources/FileSource.cs
@@ -390,6 +390,10 @@ public class FileEntry : ItemEntryBase
         EditDetails((ref file) => {
             if(tag != file.Author && !tag.IsWhiteSpace())
             {
+                 if (file.Tags == null)
+                {
+                file.Tags = new TagCollection();
+                }
                 file.Tags?.Add(tag); 
                 this.Tags.Add(tag);
             }


### PR DESCRIPTION
fix(library): initialize Tags collection on pose tag addition

Before, tags were never saved to the .pose file successfully when the Tags: portion in the .pose file was null. They were lost when restarting the game/plugin.