### PR TITLE
Update LuminaSupplemental.Excel

### DIFF
--- a/Brio/Brio.csproj
+++ b/Brio/Brio.csproj
@@ -21,7 +21,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="LuminaSupplemental.Excel" Version="4.3.7" />
+		<PackageReference Include="LuminaSupplemental.Excel" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
 		<PackageReference Include="MessagePack" Version="3.1.7" />
 		<PackageReference Include="SharpYaml" Version="3.11.0" />

--- a/Brio/packages.lock.json
+++ b/Brio/packages.lock.json
@@ -46,9 +46,9 @@
       },
       "LuminaSupplemental.Excel": {
         "type": "Direct",
-        "requested": "[4.3.7, )",
-        "resolved": "4.3.7",
-        "contentHash": "f/eJ1yg8x6FaqPnRmF6vTsdgKXKxAJpHC4byTWYKG8bktZOvBlYpDyZS5n7hbT9vUiJveuxhiEQJKnwVY76nCQ==",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "TAHch564Epy0JVb8saFo4GJSOGiTfJneh5Ny+8D18lBBNXLrCMwRsAeReYQMyfs+ETQ99+IOb6zo4MPTNL5hCQ==",
         "dependencies": {
           "CSVFile": "3.2.1",
           "CsvHelper": "30.0.1",


### PR DESCRIPTION
New version is out without BNpc name data from Gubal. It only uses Tracky's crowdsourced data now.
Already could confirm BNpc 19180 is now correctly named The Tyrant. :)