### PR TITLE
Fix lighting compatibility with other plugins

### DIFF
--- a/Brio/Game/World/Interop/BrioLight.cs
+++ b/Brio/Game/World/Interop/BrioLight.cs
@@ -17,7 +17,7 @@ public unsafe struct BrioLight
     public struct GameLightVirtualTable
     {
         [FieldOffset(0)]
-        public delegate* unmanaged<BrioLight*, bool, void> Destructor;
+        public delegate* unmanaged<BrioLight*, bool, nint> Destructor;
 
         [FieldOffset(8)]
         public delegate* unmanaged<BrioLight*, void> Cleanup;

--- a/Brio/Game/World/LightingService.cs
+++ b/Brio/Game/World/LightingService.cs
@@ -46,7 +46,7 @@ public unsafe class LightingService : MediatorSubscriberBase
     private delegate BrioLight* LightDelegate(BrioLight* light);
     private readonly Hook<LightDelegate> _lightCtorHook = null!;
 
-     public delegate* unmanaged<BrioLight*, bool, nint> Destructor;
+    public delegate* unmanaged<BrioLight*, bool, nint> Destructor;
 
     private delegate nint LightDtorDelegate(BrioLight* thisPtr, bool free);
     private Hook<LightDtorDelegate> _lightDtorHook = null!;

--- a/Brio/Game/World/LightingService.cs
+++ b/Brio/Game/World/LightingService.cs
@@ -46,9 +46,9 @@ public unsafe class LightingService : MediatorSubscriberBase
     private delegate BrioLight* LightDelegate(BrioLight* light);
     private readonly Hook<LightDelegate> _lightCtorHook = null!;
 
-    public delegate* unmanaged<BrioLight*, bool, void> Destructor;
+     public delegate* unmanaged<BrioLight*, bool, nint> Destructor;
 
-    private delegate void LightDtorDelegate(BrioLight* thisPtr, bool free);
+    private delegate nint LightDtorDelegate(BrioLight* thisPtr, bool free);
     private Hook<LightDtorDelegate> _lightDtorHook = null!;
 
     //
@@ -141,7 +141,7 @@ public unsafe class LightingService : MediatorSubscriberBase
         return value;
     }
 
-    private void LightDtor(BrioLight* light, bool free)
+    private nint LightDtor(BrioLight* light, bool free)
     {
         if(_worldGameLights.Contains((nint)light))
         {
@@ -162,7 +162,7 @@ public unsafe class LightingService : MediatorSubscriberBase
             }
         }
 
-        _lightDtorHook.Original(light, free);
+        return _lightDtorHook.Original(light, free);
     }
 
     public Entity? AddWorldLight(BrioLight* light)


### PR DESCRIPTION
Ultimately the root cause of this came down to accidentally breaking the ABI on the destructor for lights, causing flow-on effects elsewhere.

For a bit more of a technical breakdown, MSVC & the game expects that for the object destructor to return a pointer to `this` when  being declared, examples in the Client Structs can be seen [here](https://github.com/aers/FFXIVClientStructs/blob/e5d0641a8d5ce15ce7001553c5f933c30e4ff6d6/FFXIVClientStructs/FFXIV/Client/Graphics/Scene/Object.cs#L26-L27)

```cs
    [VirtualFunction(0)]
    public partial Object* Dtor(byte freeFlags);
```

What happens, is when the destructor is called, the EAX/RAX register is set within the destructor and then never mutated from the toggle light detour, so changing how that works inside can have flow-on-effects, see:

```asm
mov  rax, [rcx]
mov  edx, 1
call qword [rax]         ; vf[0] DeletingDestructor(light, flags=1) 
mov  qword [rbx+0E0h], 0
mov  rbx, [rsp+20h]
add  rsp, 28h
ret
```
Where this is simply returning the result of the destructor internally.