### PR TITLE
Add Penumbra mod action filtering and common pose shortcuts

### DIFF
--- a/Brio/Brio.cs
+++ b/Brio/Brio.cs
@@ -226,6 +226,7 @@ public class Brio(IDalamudPluginInterface pluginInterface) : IAsyncDalamudPlugin
         serviceCollection.AddSingleton<IPCManager>();
         serviceCollection.AddSingleton<DynamisService>();
         serviceCollection.AddSingleton<PenumbraService>();
+        serviceCollection.AddSingleton<PenumbraModActionService>();
         serviceCollection.AddSingleton<GlamourerService>();
         serviceCollection.AddSingleton<CustomizePlusService>();
         serviceCollection.AddSingleton<KtisisService>();

--- a/Brio/IPC/PenumbraModActionService.cs
+++ b/Brio/IPC/PenumbraModActionService.cs
@@ -1,3 +1,4 @@
+using Brio.Resources;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Plugin;
 using Lumina.Excel.Sheets;
@@ -13,22 +14,6 @@ namespace Brio.IPC;
 public sealed class PenumbraModActionService
 {
     private static readonly TimeSpan RefreshInterval = TimeSpan.FromSeconds(2);
-    private static readonly IReadOnlyDictionary<string, PoseVariantDefinition> PoseVariants =
-        new Dictionary<string, PoseVariantDefinition>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["s_pose01_loop.pap"] = new(50, 643, 1),
-            ["s_pose02_loop.pap"] = new(50, 3132, 2),
-            ["s_pose03_loop.pap"] = new(50, 3134, 3),
-            ["s_pose04_loop.pap"] = new(50, 8002, 4),
-            ["s_pose05_loop.pap"] = new(50, 8004, 5),
-            ["j_pose01_loop.pap"] = new(52, 654, 1),
-            ["j_pose02_loop.pap"] = new(52, 3136, 2),
-            ["j_pose03_loop.pap"] = new(52, 3138, 3),
-            ["j_pose04_loop.pap"] = new(52, 3771, 4),
-            ["l_pose01_loop.pap"] = new(13, 3140, 1),
-            ["l_pose02_loop.pap"] = new(13, 3142, 2),
-            ["l_pose03_loop.pap"] = new(13, 585, 3),
-        };
 
     private readonly PenumbraService _penumbraService;
     private readonly GetEnabledState _getEnabledState;
@@ -37,6 +22,7 @@ public sealed class PenumbraModActionService
     private readonly CheckCurrentChangedItemFunc _checkCurrentChangedItem;
     private readonly GetGameObjectResourcePaths _getGameObjectResourcePaths;
     private readonly GetModPath _getModPath;
+    private readonly ResolveGameObjectPath _resolveGameObjectPath;
 
     private IReadOnlyList<PenumbraModAction> _cachedActions = [];
     private string _cacheSignature = string.Empty;
@@ -56,6 +42,7 @@ public sealed class PenumbraModActionService
         _checkCurrentChangedItem = new CheckCurrentChangedItemFunc(pluginInterface);
         _getGameObjectResourcePaths = new GetGameObjectResourcePaths(pluginInterface);
         _getModPath = new GetModPath(pluginInterface);
+        _resolveGameObjectPath = new ResolveGameObjectPath(pluginInterface);
     }
 
     public IReadOnlyList<PenumbraModAction> GetActiveActions(IGameObject actor)
@@ -96,11 +83,10 @@ public sealed class PenumbraModActionService
 
             var changedItems = _getChangedItemsForCollection.Invoke(collection.Id);
             var modLookup = _checkCurrentChangedItem.Invoke();
-            var variantResources = GetVariantResources(actor.ObjectIndex);
-            var actions = BuildActions(changedItems, modLookup, variantResources);
+            var actions = BuildActions(changedItems, modLookup, actor.ObjectIndex);
             var status = actions.Count == 0
-                ? $"No active mod actions were found in {collection.Name}."
-                : $"{actions.Count} active mod actions from {collection.Name}.";
+                ? string.Format("No active mod actions were found in {0}.", collection.Name)
+                : string.Format("{0} active mod actions from {1}.", actions.Count, collection.Name);
 
             SetCache(actions, status);
         }
@@ -114,28 +100,42 @@ public sealed class PenumbraModActionService
     private IReadOnlyList<PenumbraModAction> BuildActions(
         IReadOnlyDictionary<string, object?> changedItems,
         Func<string, (string ModDirectory, string ModName)[]> modLookup,
-        IReadOnlyList<VariantResourceHit> variantResources)
+        ushort objectIndex)
     {
-        var actions = new List<PenumbraModAction>();
+        var modsByChangedItem = new Dictionary<string, IReadOnlyList<ResolvedModReference>>(StringComparer.OrdinalIgnoreCase);
+        foreach(var changedItemName in changedItems.Keys)
+        {
+            var resolved = ResolveMods(modLookup(changedItemName));
+            if(resolved.Count > 0)
+                modsByChangedItem[changedItemName] = resolved;
+        }
+
+        var allMods = modsByChangedItem.Values
+            .SelectMany(mods => mods)
+            .GroupBy(mod => mod.ModDirectory, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToList();
+
+        var variantResources = GetVariantResources(objectIndex);
+        var (variantActions, detectedModEmotes) = BuildVariantActions(allMods, variantResources, changedItems.Values.OfType<Emote>());
+        var actions = new List<PenumbraModAction>(variantActions);
+
         foreach(var (changedItemName, payload) in changedItems.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase))
         {
             if(payload is not Emote emote || emote.RowId is 0 or > ushort.MaxValue)
                 continue;
 
-            var mods = ResolveMods(modLookup(changedItemName));
-            if(mods.Count == 0)
+            if(!modsByChangedItem.TryGetValue(changedItemName, out var resolvedMods))
                 continue;
+
+            var mods = resolvedMods.ToList();
 
             var emoteName = emote.Name.ToString().Trim();
             if(string.IsNullOrWhiteSpace(emoteName))
                 emoteName = $"Emote {emote.RowId}";
 
-            if(PoseVariants.Values.Any(variant => variant.BaseEmoteId == emote.RowId))
-            {
-                var (variantActions, detectedMods) = BuildVariantActions(emote, emoteName, mods, variantResources);
-                actions.AddRange(variantActions);
-                mods = mods.Where(mod => !detectedMods.Contains(mod.ModDirectory)).ToList();
-            }
+            if(CommonPoseCatalog.All.Any(variant => variant.BaseEmoteId == emote.RowId))
+                mods = mods.Where(mod => !detectedModEmotes.Contains(VariantDetectionKey(mod.ModDirectory, emote.RowId))).ToList();
 
             if(mods.Count > 0)
                 actions.Add(new PenumbraModAction(emote, emoteName, BuildModLabel(mods.Select(mod => mod.DisplayName).ToArray()), null));
@@ -181,14 +181,46 @@ public sealed class PenumbraModActionService
                 return [];
 
             var hits = new List<VariantResourceHit>();
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var variantsByFileName = new Dictionary<string, CommonPoseDefinition>(StringComparer.OrdinalIgnoreCase);
+            foreach(var definition in CommonPoseCatalog.All)
+            {
+                if(GameDataProvider.Instance.ActionTimelines.TryGetRow(definition.TimelineId, out var timeline))
+                    variantsByFileName[$"{timeline.Key}.pap"] = definition;
+            }
+
             foreach(var actualPath in pathMap.Keys)
             {
                 if(string.IsNullOrWhiteSpace(actualPath))
                     continue;
 
                 var fileName = Path.GetFileName(actualPath);
-                if(!string.IsNullOrWhiteSpace(fileName) && PoseVariants.TryGetValue(fileName, out var definition))
+                if(!string.IsNullOrWhiteSpace(fileName) && variantsByFileName.TryGetValue(fileName, out var definition)
+                    && seen.Add($"{actualPath}|{definition.TimelineId}"))
                     hits.Add(new VariantResourceHit(actualPath, definition));
+            }
+
+            var residentDirectories = pathMap.Values
+                .SelectMany(paths => paths)
+                .Select(NormalizeGamePath)
+                .Where(path => path.Contains("/bt_common/resident/", StringComparison.OrdinalIgnoreCase))
+                .Select(path => path[..path.LastIndexOf('/')])
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            foreach(var residentDirectory in residentDirectories)
+            {
+                foreach(var (fileName, definition) in variantsByFileName)
+                {
+                    var gamePath = $"{residentDirectory}/{fileName}";
+                    var resolvedPath = _resolveGameObjectPath.Invoke(gamePath, objectIndex);
+                    if(string.IsNullOrWhiteSpace(resolvedPath)
+                        || string.Equals(NormalizeGamePath(resolvedPath), gamePath, StringComparison.OrdinalIgnoreCase)
+                        || !seen.Add($"{resolvedPath}|{definition.TimelineId}"))
+                        continue;
+
+                    hits.Add(new VariantResourceHit(resolvedPath, definition));
+                }
             }
 
             return hits;
@@ -200,15 +232,17 @@ public sealed class PenumbraModActionService
         }
     }
 
-    private static (IReadOnlyList<PenumbraModAction> Actions, IReadOnlySet<string> DetectedMods) BuildVariantActions(
-        Emote emote,
-        string emoteName,
+    private static (IReadOnlyList<PenumbraModAction> Actions, IReadOnlySet<string> DetectedModEmotes) BuildVariantActions(
         IReadOnlyList<ResolvedModReference> mods,
-        IReadOnlyList<VariantResourceHit> variantResources)
+        IReadOnlyList<VariantResourceHit> variantResources,
+        IEnumerable<Emote> emotes)
     {
         var actions = new List<PenumbraModAction>();
-        var detectedMods = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var detectedModEmotes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var emotesById = emotes
+            .GroupBy(emote => emote.RowId)
+            .ToDictionary(group => group.Key, group => group.First());
 
         foreach(var mod in mods)
         {
@@ -216,23 +250,36 @@ public sealed class PenumbraModActionService
                 continue;
 
             foreach(var hit in variantResources
-                .Where(hit => hit.Definition.BaseEmoteId == emote.RowId && IsPathInDirectory(hit.ActualPath, mod.PathPrefix))
-                .OrderBy(hit => hit.Definition.SortOrder))
+                .Where(hit => IsPathInDirectory(hit.ActualPath, mod.PathPrefix))
+                .OrderBy(hit => hit.Definition.Kind)
+                .ThenBy(hit => hit.Definition.VariantIndex))
             {
                 if(!seen.Add($"{mod.ModDirectory}|{hit.Definition.TimelineId}"))
                     continue;
 
+                Emote? emote = null;
+                if(hit.Definition.BaseEmoteId != 0 && emotesById.TryGetValue(hit.Definition.BaseEmoteId, out var baseEmote))
+                    emote = baseEmote;
+
                 actions.Add(new PenumbraModAction(
                     emote,
-                    $"{emoteName} {hit.Definition.SortOrder}",
+                    hit.Definition.DisplayName,
                     mod.DisplayName,
                     hit.Definition.TimelineId));
-                detectedMods.Add(mod.ModDirectory);
+
+                if(hit.Definition.BaseEmoteId != 0)
+                    detectedModEmotes.Add(VariantDetectionKey(mod.ModDirectory, hit.Definition.BaseEmoteId));
             }
         }
 
-        return (actions, detectedMods);
+        return (actions, detectedModEmotes);
     }
+
+    private static string NormalizeGamePath(string path)
+        => path.Replace('\\', '/');
+
+    private static string VariantDetectionKey(string modDirectory, uint baseEmoteId)
+        => $"{modDirectory}|{baseEmoteId}";
 
     private static string BuildModLabel(IReadOnlyList<string> names)
         => names.Count switch
@@ -258,7 +305,7 @@ public sealed class PenumbraModActionService
 
     private void SetCache(IReadOnlyList<PenumbraModAction> actions, string status)
     {
-        var signature = string.Join('\n', actions.Select(action => $"{action.Emote.RowId}|{action.ModName}|{action.TimelineId}"));
+        var signature = string.Join('\n', actions.Select(action => $"{action.Emote?.RowId ?? 0}|{action.ModName}|{action.TimelineId}"));
         if(!string.Equals(_cacheSignature, signature, StringComparison.Ordinal))
         {
             _cachedActions = actions;
@@ -270,8 +317,7 @@ public sealed class PenumbraModActionService
     }
 
     private sealed record ResolvedModReference(string ModDirectory, string DisplayName, string? PathPrefix);
-    private sealed record VariantResourceHit(string ActualPath, PoseVariantDefinition Definition);
-    private readonly record struct PoseVariantDefinition(uint BaseEmoteId, uint TimelineId, int SortOrder);
+    private sealed record VariantResourceHit(string ActualPath, CommonPoseDefinition Definition);
 }
 
-public sealed record PenumbraModAction(Emote Emote, string EmoteName, string ModName, uint? TimelineId);
+public sealed record PenumbraModAction(Emote? Emote, string EmoteName, string ModName, uint? TimelineId);

--- a/Brio/IPC/PenumbraModActionService.cs
+++ b/Brio/IPC/PenumbraModActionService.cs
@@ -1,0 +1,277 @@
+using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Plugin;
+using Lumina.Excel.Sheets;
+using Penumbra.Api.Enums;
+using Penumbra.Api.IpcSubscribers;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Brio.IPC;
+
+public sealed class PenumbraModActionService
+{
+    private static readonly TimeSpan RefreshInterval = TimeSpan.FromSeconds(2);
+    private static readonly IReadOnlyDictionary<string, PoseVariantDefinition> PoseVariants =
+        new Dictionary<string, PoseVariantDefinition>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["s_pose01_loop.pap"] = new(50, 643, 1),
+            ["s_pose02_loop.pap"] = new(50, 3132, 2),
+            ["s_pose03_loop.pap"] = new(50, 3134, 3),
+            ["s_pose04_loop.pap"] = new(50, 8002, 4),
+            ["s_pose05_loop.pap"] = new(50, 8004, 5),
+            ["j_pose01_loop.pap"] = new(52, 654, 1),
+            ["j_pose02_loop.pap"] = new(52, 3136, 2),
+            ["j_pose03_loop.pap"] = new(52, 3138, 3),
+            ["j_pose04_loop.pap"] = new(52, 3771, 4),
+            ["l_pose01_loop.pap"] = new(13, 3140, 1),
+            ["l_pose02_loop.pap"] = new(13, 3142, 2),
+            ["l_pose03_loop.pap"] = new(13, 585, 3),
+        };
+
+    private readonly PenumbraService _penumbraService;
+    private readonly GetEnabledState _getEnabledState;
+    private readonly GetCollectionForObject _getCollectionForObject;
+    private readonly GetChangedItemsForCollection _getChangedItemsForCollection;
+    private readonly CheckCurrentChangedItemFunc _checkCurrentChangedItem;
+    private readonly GetGameObjectResourcePaths _getGameObjectResourcePaths;
+    private readonly GetModPath _getModPath;
+
+    private IReadOnlyList<PenumbraModAction> _cachedActions = [];
+    private string _cacheSignature = string.Empty;
+    private string _statusMessage = "Penumbra mod actions have not been scanned yet.";
+    private DateTime _nextRefreshAtUtc = DateTime.MinValue;
+    private ushort _cachedObjectIndex = ushort.MaxValue;
+
+    public int Version { get; private set; }
+    public string StatusMessage => _statusMessage;
+
+    public PenumbraModActionService(IDalamudPluginInterface pluginInterface, PenumbraService penumbraService)
+    {
+        _penumbraService = penumbraService;
+        _getEnabledState = new GetEnabledState(pluginInterface);
+        _getCollectionForObject = new GetCollectionForObject(pluginInterface);
+        _getChangedItemsForCollection = new GetChangedItemsForCollection(pluginInterface);
+        _checkCurrentChangedItem = new CheckCurrentChangedItemFunc(pluginInterface);
+        _getGameObjectResourcePaths = new GetGameObjectResourcePaths(pluginInterface);
+        _getModPath = new GetModPath(pluginInterface);
+    }
+
+    public IReadOnlyList<PenumbraModAction> GetActiveActions(IGameObject actor)
+    {
+        var objectChanged = _cachedObjectIndex != actor.ObjectIndex;
+        if(!objectChanged && DateTime.UtcNow < _nextRefreshAtUtc)
+            return _cachedActions;
+
+        _cachedObjectIndex = actor.ObjectIndex;
+        _nextRefreshAtUtc = DateTime.UtcNow + RefreshInterval;
+
+        Refresh(actor);
+        return _cachedActions;
+    }
+
+    private void Refresh(IGameObject actor)
+    {
+        try
+        {
+            if(!_penumbraService.AllowIntegration || !_penumbraService.IsAvailable)
+            {
+                SetCache([], "Penumbra integration is unavailable or disabled.");
+                return;
+            }
+
+            if(!_getEnabledState.Invoke())
+            {
+                SetCache([], "Penumbra is currently disabled.");
+                return;
+            }
+
+            var (objectValid, _, collection) = _getCollectionForObject.Invoke(actor.ObjectIndex);
+            if(!objectValid)
+            {
+                SetCache([], "The actor's Penumbra collection could not be resolved.");
+                return;
+            }
+
+            var changedItems = _getChangedItemsForCollection.Invoke(collection.Id);
+            var modLookup = _checkCurrentChangedItem.Invoke();
+            var variantResources = GetVariantResources(actor.ObjectIndex);
+            var actions = BuildActions(changedItems, modLookup, variantResources);
+            var status = actions.Count == 0
+                ? $"No active mod actions were found in {collection.Name}."
+                : $"{actions.Count} active mod actions from {collection.Name}.";
+
+            SetCache(actions, status);
+        }
+        catch(Exception ex)
+        {
+            Brio.Log.Warning(ex, "Failed to scan Penumbra mod actions");
+            SetCache([], "Failed to scan Penumbra mod actions.");
+        }
+    }
+
+    private IReadOnlyList<PenumbraModAction> BuildActions(
+        IReadOnlyDictionary<string, object?> changedItems,
+        Func<string, (string ModDirectory, string ModName)[]> modLookup,
+        IReadOnlyList<VariantResourceHit> variantResources)
+    {
+        var actions = new List<PenumbraModAction>();
+        foreach(var (changedItemName, payload) in changedItems.OrderBy(item => item.Key, StringComparer.OrdinalIgnoreCase))
+        {
+            if(payload is not Emote emote || emote.RowId is 0 or > ushort.MaxValue)
+                continue;
+
+            var mods = ResolveMods(modLookup(changedItemName));
+            if(mods.Count == 0)
+                continue;
+
+            var emoteName = emote.Name.ToString().Trim();
+            if(string.IsNullOrWhiteSpace(emoteName))
+                emoteName = $"Emote {emote.RowId}";
+
+            if(PoseVariants.Values.Any(variant => variant.BaseEmoteId == emote.RowId))
+            {
+                var (variantActions, detectedMods) = BuildVariantActions(emote, emoteName, mods, variantResources);
+                actions.AddRange(variantActions);
+                mods = mods.Where(mod => !detectedMods.Contains(mod.ModDirectory)).ToList();
+            }
+
+            if(mods.Count > 0)
+                actions.Add(new PenumbraModAction(emote, emoteName, BuildModLabel(mods.Select(mod => mod.DisplayName).ToArray()), null));
+        }
+
+        return actions;
+    }
+
+    private IReadOnlyList<ResolvedModReference> ResolveMods((string ModDirectory, string ModName)[] modPairs)
+    {
+        var mods = new List<ResolvedModReference>(modPairs.Length);
+        foreach(var (modDirectory, modName) in modPairs)
+        {
+            var displayName = string.IsNullOrWhiteSpace(modName) ? modDirectory : modName;
+            if(string.IsNullOrWhiteSpace(displayName)
+                || mods.Any(mod => string.Equals(mod.ModDirectory, modDirectory, StringComparison.OrdinalIgnoreCase)))
+                continue;
+
+            string? pathPrefix = null;
+            try
+            {
+                var (result, fullPath, _, _) = _getModPath.Invoke(modDirectory, modName);
+                if(result == PenumbraApiEc.Success && !string.IsNullOrWhiteSpace(fullPath))
+                    pathPrefix = NormalizeDirectoryPrefix(fullPath);
+            }
+            catch(Exception ex)
+            {
+                Brio.Log.Debug(ex, "Failed to resolve the Penumbra path for {ModDirectory}", modDirectory);
+            }
+
+            mods.Add(new ResolvedModReference(modDirectory, displayName, pathPrefix));
+        }
+
+        return mods.OrderBy(mod => mod.DisplayName, StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    private IReadOnlyList<VariantResourceHit> GetVariantResources(ushort objectIndex)
+    {
+        try
+        {
+            var resources = _getGameObjectResourcePaths.Invoke(objectIndex);
+            if(resources.Length == 0 || resources[0] is not { } pathMap)
+                return [];
+
+            var hits = new List<VariantResourceHit>();
+            foreach(var actualPath in pathMap.Keys)
+            {
+                if(string.IsNullOrWhiteSpace(actualPath))
+                    continue;
+
+                var fileName = Path.GetFileName(actualPath);
+                if(!string.IsNullOrWhiteSpace(fileName) && PoseVariants.TryGetValue(fileName, out var definition))
+                    hits.Add(new VariantResourceHit(actualPath, definition));
+            }
+
+            return hits;
+        }
+        catch(Exception ex)
+        {
+            Brio.Log.Debug(ex, "Failed to inspect Penumbra pose variant resources");
+            return [];
+        }
+    }
+
+    private static (IReadOnlyList<PenumbraModAction> Actions, IReadOnlySet<string> DetectedMods) BuildVariantActions(
+        Emote emote,
+        string emoteName,
+        IReadOnlyList<ResolvedModReference> mods,
+        IReadOnlyList<VariantResourceHit> variantResources)
+    {
+        var actions = new List<PenumbraModAction>();
+        var detectedMods = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach(var mod in mods)
+        {
+            if(string.IsNullOrWhiteSpace(mod.PathPrefix))
+                continue;
+
+            foreach(var hit in variantResources
+                .Where(hit => hit.Definition.BaseEmoteId == emote.RowId && IsPathInDirectory(hit.ActualPath, mod.PathPrefix))
+                .OrderBy(hit => hit.Definition.SortOrder))
+            {
+                if(!seen.Add($"{mod.ModDirectory}|{hit.Definition.TimelineId}"))
+                    continue;
+
+                actions.Add(new PenumbraModAction(
+                    emote,
+                    $"{emoteName} {hit.Definition.SortOrder}",
+                    mod.DisplayName,
+                    hit.Definition.TimelineId));
+                detectedMods.Add(mod.ModDirectory);
+            }
+        }
+
+        return (actions, detectedMods);
+    }
+
+    private static string BuildModLabel(IReadOnlyList<string> names)
+        => names.Count switch
+        {
+            0 => string.Empty,
+            1 => names[0],
+            2 => $"{names[0]} / {names[1]}",
+            _ => $"{names[0]} +{names.Count - 1}",
+        };
+
+    private static string NormalizeDirectoryPrefix(string path)
+    {
+        var normalized = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
+            .TrimEnd(Path.DirectorySeparatorChar);
+        return $"{normalized}{Path.DirectorySeparatorChar}";
+    }
+
+    private static bool IsPathInDirectory(string actualPath, string pathPrefix)
+    {
+        var normalizedPath = actualPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        return normalizedPath.StartsWith(pathPrefix, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void SetCache(IReadOnlyList<PenumbraModAction> actions, string status)
+    {
+        var signature = string.Join('\n', actions.Select(action => $"{action.Emote.RowId}|{action.ModName}|{action.TimelineId}"));
+        if(!string.Equals(_cacheSignature, signature, StringComparison.Ordinal))
+        {
+            _cachedActions = actions;
+            _cacheSignature = signature;
+            Version++;
+        }
+
+        _statusMessage = status;
+    }
+
+    private sealed record ResolvedModReference(string ModDirectory, string DisplayName, string? PathPrefix);
+    private sealed record VariantResourceHit(string ActualPath, PoseVariantDefinition Definition);
+    private readonly record struct PoseVariantDefinition(uint BaseEmoteId, uint TimelineId, int SortOrder);
+}
+
+public sealed record PenumbraModAction(Emote Emote, string EmoteName, string ModName, uint? TimelineId);

--- a/Brio/Resources/CommonPoseCatalog.cs
+++ b/Brio/Resources/CommonPoseCatalog.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+
+namespace Brio.Resources;
+
+public enum CommonPoseKind
+{
+    ChairSit,
+    Standing,
+    GroundSit,
+    Sleep,
+}
+
+public readonly record struct CommonPoseDefinition(
+    uint TimelineId,
+    CommonPoseKind Kind,
+    int VariantIndex,
+    uint BaseEmoteId)
+{
+    public string DisplayName => (Kind, VariantIndex) switch
+    {
+        (CommonPoseKind.ChairSit, 0) => "Base Chair Sit Pose",
+        (CommonPoseKind.ChairSit, _) => string.Format("Chair Sit Pose {0:D2}", VariantIndex),
+        (CommonPoseKind.Standing, 0) => "Base Standing Pose",
+        (CommonPoseKind.Standing, _) => string.Format("Standing Pose {0:D2}", VariantIndex),
+        (CommonPoseKind.GroundSit, 0) => "Base Ground Sit Pose",
+        (CommonPoseKind.GroundSit, _) => string.Format("Ground Sit Pose {0:D2}", VariantIndex),
+        (CommonPoseKind.Sleep, _) => string.Format("Sleep Pose {0:D2}", VariantIndex),
+        _ => string.Format("Timeline {0}", TimelineId),
+    };
+}
+
+public static class CommonPoseCatalog
+{
+    public static IReadOnlyList<CommonPoseDefinition> All { get; } =
+    [
+        new(643, CommonPoseKind.ChairSit, 0, 50),
+        new(3132, CommonPoseKind.ChairSit, 1, 50),
+        new(3134, CommonPoseKind.ChairSit, 2, 50),
+        new(8002, CommonPoseKind.ChairSit, 3, 50),
+        new(8004, CommonPoseKind.ChairSit, 4, 50),
+
+        new(3, CommonPoseKind.Standing, 0, 0),
+        new(3124, CommonPoseKind.Standing, 1, 0),
+        new(3126, CommonPoseKind.Standing, 2, 0),
+        new(3182, CommonPoseKind.Standing, 3, 0),
+        new(3184, CommonPoseKind.Standing, 4, 0),
+        new(7405, CommonPoseKind.Standing, 5, 0),
+        new(7407, CommonPoseKind.Standing, 6, 0),
+
+        new(654, CommonPoseKind.GroundSit, 0, 52),
+        new(3136, CommonPoseKind.GroundSit, 1, 52),
+        new(3138, CommonPoseKind.GroundSit, 2, 52),
+        new(3771, CommonPoseKind.GroundSit, 3, 52),
+
+        new(3140, CommonPoseKind.Sleep, 1, 13),
+        new(3142, CommonPoseKind.Sleep, 2, 13),
+        new(585, CommonPoseKind.Sleep, 3, 13),
+    ];
+}

--- a/Brio/UI/Controls/Editors/ActionTimelineEditor.cs
+++ b/Brio/UI/Controls/Editors/ActionTimelineEditor.cs
@@ -78,6 +78,7 @@ public class ActionTimelineEditor(CutsceneManager cutsceneManager, GPoseService 
     public void Draw(bool drawAdvanced, ActionTimelineCapability capability)
     {
         _capability = capability;
+        _globalTimelineSelector.ModActionActor = capability.GameObject;
 
         _globalTimelineSelector.DrawAsWindow();
 

--- a/Brio/UI/Controls/Selectors/ActionTimelineSelector.cs
+++ b/Brio/UI/Controls/Selectors/ActionTimelineSelector.cs
@@ -1,12 +1,15 @@
+using Brio.IPC;
 using Brio.Resources;
 using Brio.Resources.Sheets;
 using Brio.UI.Controls.Core;
 using Brio.UI.Controls.Stateless;
 using Brio.UI.Theming;
 using Dalamud.Bindings.ImGui;
+using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Interface;
 using Lumina.Excel.Sheets;
 using System;
+using System.Collections.Generic;
 using System.Numerics;
 using static Brio.Game.Actor.ActionTimelineService;
 using ActionSheet = Lumina.Excel.Sheets.Action;
@@ -25,6 +28,7 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
     private bool _showRaw = true;
     private bool _showEmotes = true;
     private bool _showActions = false;
+    private bool _showMods = true;
     private bool _showBlendable = true;
 
     private bool _filterByDrawsWeapon = false;
@@ -38,7 +42,23 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
     private bool _isPinned = false;
     private bool _isWindowOpen = false;
 
+    private IGameObject? _modActionActor;
+    private IReadOnlyList<PenumbraModAction> _modActions = [];
+    private int _modActionVersion = -1;
+
     public bool IsPinned => _isPinned;
+
+    public IGameObject? ModActionActor
+    {
+        get => _modActionActor;
+        set
+        {
+            var changed = _modActionActor?.ObjectIndex != value?.ObjectIndex;
+            _modActionActor = value;
+            if(changed)
+                _modActionVersion = -1;
+        }
+    }
 
     //TODO(KEN) at some point make all of them use `field`
 
@@ -73,6 +93,8 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
 
     public void DrawAsWindow()
     {
+        RefreshModActions();
+
         if(!_isPinned)
             return;
 
@@ -116,6 +138,8 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
 
     public new void Draw()
     {
+        RefreshModActions();
+
         if(_isPinned)
         {
             ImGui.TextDisabled("(Selector is pinned as separate window)");
@@ -125,6 +149,20 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
         DrawPinButton();
 
         base.Draw();
+    }
+
+    private void RefreshModActions()
+    {
+        if(_modActionActor is null || !Brio.TryGetService<PenumbraModActionService>(out var service))
+            return;
+
+        var actions = service.GetActiveActions(_modActionActor);
+        if(_modActionVersion == service.Version)
+            return;
+
+        _modActions = actions;
+        _modActionVersion = service.Version;
+        ReloadList();
     }
 
     protected override void PopulateList()
@@ -247,6 +285,48 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
                     false,
                     0));
         }
+
+        foreach(var modAction in _modActions)
+        {
+            if(modAction.TimelineId is uint timelineId)
+            {
+                AddModTimeline(modAction, timelineId, ActionTimelineSelectorEntry.AnimationPurpose.Standard);
+            }
+            else
+            {
+                AddModTimeline(modAction, 0, ActionTimelineSelectorEntry.AnimationPurpose.Standard);
+                AddModTimeline(modAction, 1, ActionTimelineSelectorEntry.AnimationPurpose.Intro);
+                AddModTimeline(modAction, 2, ActionTimelineSelectorEntry.AnimationPurpose.Ground);
+                AddModTimeline(modAction, 3, ActionTimelineSelectorEntry.AnimationPurpose.Chair);
+                AddModTimeline(modAction, 4, ActionTimelineSelectorEntry.AnimationPurpose.Blend);
+            }
+        }
+    }
+
+    private void AddModTimeline(PenumbraModAction modAction, int timelineIndex, ActionTimelineSelectorEntry.AnimationPurpose purpose)
+    {
+        var timelineId = modAction.Emote.ActionTimeline[timelineIndex].RowId;
+        AddModTimeline(modAction, timelineId, purpose);
+    }
+
+    private void AddModTimeline(PenumbraModAction modAction, uint timelineId, ActionTimelineSelectorEntry.AnimationPurpose purpose)
+    {
+        var emote = modAction.Emote;
+        if(timelineId == 0 || timelineId > ushort.MaxValue
+            || !GameDataProvider.Instance.ActionTimelines.TryGetRow(timelineId, out BrioActionTimeline timeline))
+            return;
+
+        AddItem(new ActionTimelineSelectorEntry(
+            $"{modAction.ModName} - {modAction.EmoteName}",
+            (ushort)timelineId,
+            emote.RowId,
+            timeline.Key.ToString(),
+            ActionTimelineSelectorEntry.OriginalType.Mod,
+            purpose,
+            (ActionTimelineSlots)timeline.Slot,
+            emote.Icon,
+            emote.DrawsWeapon,
+            (byte)emote.EmoteCategory.RowId));
     }
 
     protected override void DrawItem(ActionTimelineSelectorEntry item, bool isSoftSelected)
@@ -266,18 +346,22 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
         if(ExpressionsOnly)
             return;
 
-        bool[] items = [_showEmotes, _showActions, _showRaw];
+        bool[] items = [_showEmotes, _showActions, _showRaw, _showMods];
 
-        var changed = ImBrio.ToggleSelecterStrip("actiontimeline_filters_selector", Vector2.Zero, ref items, ["Emotes", "Actions", "Timelines"]);
+        var changed = ImBrio.ToggleSelecterStrip("actiontimeline_filters_selector", Vector2.Zero, ref items, ["Emotes", "Actions", "Timelines", "Mod"]);
 
         if(changed)
         {
             _showEmotes = items[0];
             _showActions = items[1];
             _showRaw = items[2];
+            _showMods = items[3];
 
             UpdateList();
         }
+
+        if(_showMods && Brio.TryGetService<PenumbraModActionService>(out var modActionService))
+            ImGui.TextDisabled(modActionService.StatusMessage);
 
         ImBrio.VerticalPadding(4);
 
@@ -380,8 +464,10 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
         if(!searchText.Contains(search, StringComparison.InvariantCultureIgnoreCase))
             return false;
 
+        var isEmote = item.TimelineType is ActionTimelineSelectorEntry.OriginalType.Emote or ActionTimelineSelectorEntry.OriginalType.Mod;
+
         if(ExpressionsOnly)
-            return item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Emote && item.EmoteCategory == 3 && item.Purpose == ActionTimelineSelectorEntry.AnimationPurpose.Blend;
+            return isEmote && item.EmoteCategory == 3 && item.Purpose == ActionTimelineSelectorEntry.AnimationPurpose.Blend;
 
         if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Emote && !_showEmotes)
             return false;
@@ -392,13 +478,16 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
         if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Raw && !_showRaw)
             return false;
 
+        if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Mod && !_showMods)
+            return false;
+
         if(item.Slot != ActionTimelineSlots.Base && !_showBlendable)
             return false;
 
         // When in blend mode, filter out non-blend animations unless option is enabled
         if(_showBlendable && !_showNonBlendInBlendMode)
         {
-            if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Emote)
+            if(isEmote)
             {
                 if(item.Purpose != ActionTimelineSelectorEntry.AnimationPurpose.Blend)
                     return false;
@@ -407,7 +496,7 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
 
         if(_filterByDrawsWeapon)
         {
-            if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Emote)
+            if(isEmote)
             {
                 if(item.DrawsWeapon != _drawsWeaponValue)
                     return false;
@@ -416,7 +505,7 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
 
         if(_filterByEmoteCategory)
         {
-            if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Emote)
+            if(isEmote)
             {
                 if(item.EmoteCategory != _emoteCategoryValue)
                     return false;
@@ -456,5 +545,6 @@ public record class ActionTimelineSelectorEntry(
         Raw,
         Emote,
         Action,
+        Mod,
     }
 }

--- a/Brio/UI/Controls/Selectors/ActionTimelineSelector.cs
+++ b/Brio/UI/Controls/Selectors/ActionTimelineSelector.cs
@@ -28,7 +28,6 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
     private bool _showRaw = true;
     private bool _showEmotes = true;
     private bool _showActions = false;
-    private bool _showMods = true;
     private bool _showBlendable = true;
 
     private bool _filterByDrawsWeapon = false;
@@ -286,6 +285,25 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
                     0));
         }
 
+        foreach(var pose in CommonPoseCatalog.All)
+        {
+            if(pose.TimelineId > ushort.MaxValue
+                || !GameDataProvider.Instance.ActionTimelines.TryGetRow(pose.TimelineId, out BrioActionTimeline timeline))
+                continue;
+
+            AddItem(new ActionTimelineSelectorEntry(
+                pose.DisplayName,
+                (ushort)pose.TimelineId,
+                pose.TimelineId,
+                timeline.Key.ToString(),
+                ActionTimelineSelectorEntry.OriginalType.Pose,
+                ActionTimelineSelectorEntry.AnimationPurpose.Standard,
+                (ActionTimelineSlots)timeline.Slot,
+                0,
+                false,
+                0));
+        }
+
         foreach(var modAction in _modActions)
         {
             if(modAction.TimelineId is uint timelineId)
@@ -305,7 +323,10 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
 
     private void AddModTimeline(PenumbraModAction modAction, int timelineIndex, ActionTimelineSelectorEntry.AnimationPurpose purpose)
     {
-        var timelineId = modAction.Emote.ActionTimeline[timelineIndex].RowId;
+        if(modAction.Emote is not Emote emote)
+            return;
+
+        var timelineId = emote.ActionTimeline[timelineIndex].RowId;
         AddModTimeline(modAction, timelineId, purpose);
     }
 
@@ -319,14 +340,14 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
         AddItem(new ActionTimelineSelectorEntry(
             $"{modAction.ModName} - {modAction.EmoteName}",
             (ushort)timelineId,
-            emote.RowId,
+            emote?.RowId ?? timelineId,
             timeline.Key.ToString(),
             ActionTimelineSelectorEntry.OriginalType.Mod,
             purpose,
             (ActionTimelineSlots)timeline.Slot,
-            emote.Icon,
-            emote.DrawsWeapon,
-            (byte)emote.EmoteCategory.RowId));
+            emote?.Icon ?? 0,
+            emote?.DrawsWeapon ?? false,
+            emote is Emote value ? (byte)value.EmoteCategory.RowId : (byte)0));
     }
 
     protected override void DrawItem(ActionTimelineSelectorEntry item, bool isSoftSelected)
@@ -346,21 +367,22 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
         if(ExpressionsOnly)
             return;
 
-        bool[] items = [_showEmotes, _showActions, _showRaw, _showMods];
+        bool[] items = [_showEmotes, _showActions, _showRaw];
 
-        var changed = ImBrio.ToggleSelecterStrip("actiontimeline_filters_selector", Vector2.Zero, ref items, ["Emotes", "Actions", "Timelines", "Mod"]);
+        var changed = ImBrio.ToggleSelecterStrip("actiontimeline_filters_selector", Vector2.Zero, ref items,
+            ["Emotes", "Actions", "Timelines"]);
 
         if(changed)
         {
             _showEmotes = items[0];
             _showActions = items[1];
             _showRaw = items[2];
-            _showMods = items[3];
 
             UpdateList();
         }
 
-        if(_showMods && Brio.TryGetService<PenumbraModActionService>(out var modActionService))
+        if(_emoteCategoryValue == 4 && _modActions.Count == 0
+            && Brio.TryGetService<PenumbraModActionService>(out var modActionService))
             ImGui.TextDisabled(modActionService.StatusMessage);
 
         ImBrio.VerticalPadding(4);
@@ -380,7 +402,8 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
 
             int drawsWeaponSelection = !_filterByDrawsWeapon ? 0 : (_drawsWeaponValue ? 2 : 1);
 
-            if(ImBrio.ButtonSelectorStrip("draws_weapon_filter", Vector2.Zero, ref drawsWeaponSelection, ["All", "Sheathed", "Drawn"]))
+            if(ImBrio.ButtonSelectorStrip("draws_weapon_filter", Vector2.Zero, ref drawsWeaponSelection,
+                ["All", "Sheathed", "Drawn"]))
             {
                 switch(drawsWeaponSelection)
                 {
@@ -409,10 +432,11 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
 
         int emoteCategorySelection = _emoteCategoryValue;
 
-        if(ImBrio.ButtonSelectorStrip("emote_category_filter", Vector2.Zero, ref emoteCategorySelection, ["All", "General", "Special", "Expression"]))
+        if(ImBrio.ButtonSelectorStrip("emote_category_filter", Vector2.Zero, ref emoteCategorySelection,
+            ["All", "General", "Special", "Expression", "Mod", "Poses"]))
         {
             _emoteCategoryValue = emoteCategorySelection;
-            _filterByEmoteCategory = _emoteCategoryValue != 0;
+            _filterByEmoteCategory = _emoteCategoryValue is >= 1 and <= 3;
             UpdateList();
         }
 
@@ -421,19 +445,9 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
 
     protected override int Compare(ActionTimelineSelectorEntry itemA, ActionTimelineSelectorEntry itemB)
     {
-        // Emotes first
-        if(itemA.TimelineType == ActionTimelineSelectorEntry.OriginalType.Emote && itemB.TimelineType != ActionTimelineSelectorEntry.OriginalType.Emote)
-            return -1;
-
-        if(itemA.TimelineType != ActionTimelineSelectorEntry.OriginalType.Emote && itemB.TimelineType == ActionTimelineSelectorEntry.OriginalType.Emote)
-            return 1;
-
-        // Then Actions
-        if(itemA.TimelineType == ActionTimelineSelectorEntry.OriginalType.Action && itemB.TimelineType != ActionTimelineSelectorEntry.OriginalType.Action)
-            return -1;
-
-        if(itemA.TimelineType != ActionTimelineSelectorEntry.OriginalType.Action && itemB.TimelineType == ActionTimelineSelectorEntry.OriginalType.Action)
-            return 1;
+        var typeCompare = TypePriority(itemA.TimelineType).CompareTo(TypePriority(itemB.TimelineType));
+        if(typeCompare != 0)
+            return typeCompare;
 
         // Blank to last
         if(string.IsNullOrEmpty(itemA.Name) && !string.IsNullOrEmpty(itemB.Name))
@@ -457,6 +471,16 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
         return 0;
     }
 
+    private static int TypePriority(ActionTimelineSelectorEntry.OriginalType type)
+        => type switch
+        {
+            ActionTimelineSelectorEntry.OriginalType.Emote => 0,
+            ActionTimelineSelectorEntry.OriginalType.Pose => 1,
+            ActionTimelineSelectorEntry.OriginalType.Mod => 2,
+            ActionTimelineSelectorEntry.OriginalType.Action => 3,
+            _ => 4,
+        };
+
     protected override bool Filter(ActionTimelineSelectorEntry item, string search)
     {
         var searchText = $"{item.Name} {item.TimelineId} {item.TimelineType} {item.Slot} {item.Purpose} {item.Key} {item.SecondaryId}";
@@ -464,21 +488,20 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
         if(!searchText.Contains(search, StringComparison.InvariantCultureIgnoreCase))
             return false;
 
-        var isEmote = item.TimelineType is ActionTimelineSelectorEntry.OriginalType.Emote or ActionTimelineSelectorEntry.OriginalType.Mod;
+        var isEmote = item.TimelineType is ActionTimelineSelectorEntry.OriginalType.Emote
+            or ActionTimelineSelectorEntry.OriginalType.Mod
+            or ActionTimelineSelectorEntry.OriginalType.Pose;
 
         if(ExpressionsOnly)
             return isEmote && item.EmoteCategory == 3 && item.Purpose == ActionTimelineSelectorEntry.AnimationPurpose.Blend;
 
-        if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Emote && !_showEmotes)
+        if(isEmote && !_showEmotes)
             return false;
 
         if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Action && !_showActions)
             return false;
 
         if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Raw && !_showRaw)
-            return false;
-
-        if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Mod && !_showMods)
             return false;
 
         if(item.Slot != ActionTimelineSlots.Base && !_showBlendable)
@@ -505,12 +528,21 @@ public class ActionTimelineSelector(string id) : Selector<ActionTimelineSelector
 
         if(_filterByEmoteCategory)
         {
-            if(isEmote)
+            if(item.TimelineType is ActionTimelineSelectorEntry.OriginalType.Mod or ActionTimelineSelectorEntry.OriginalType.Pose)
+                return false;
+
+            if(item.TimelineType == ActionTimelineSelectorEntry.OriginalType.Emote)
             {
                 if(item.EmoteCategory != _emoteCategoryValue)
                     return false;
             }
         }
+
+        if(_emoteCategoryValue == 4 && item.TimelineType != ActionTimelineSelectorEntry.OriginalType.Mod)
+            return false;
+
+        if(_emoteCategoryValue == 5 && item.TimelineType != ActionTimelineSelectorEntry.OriginalType.Pose)
+            return false;
 
         return true;
     }
@@ -546,5 +578,6 @@ public record class ActionTimelineSelectorEntry(
         Emote,
         Action,
         Mod,
+        Pose,
     }
 }

--- a/Brio/UI/Controls/Selectors/Selector.cs
+++ b/Brio/UI/Controls/Selectors/Selector.cs
@@ -260,6 +260,17 @@ public abstract class Selector<T> where T : class
         }, TaskScheduler.Default);
     }
 
+    protected void ReloadList()
+    {
+        _taskQueue = _taskQueue.ContinueWith(_ =>
+        {
+            _items.Clear();
+            PopulateList();
+        }, TaskScheduler.Default);
+
+        UpdateList(shouldClear: true);
+    }
+
     protected virtual bool Filter(T item, string search)
     {
         return true;


### PR DESCRIPTION
## Summary

- Adds a **Mod** category to the action timeline selector for animations replaced by enabled Penumbra mods.
- Adds a dedicated **Poses** category with quick access to common chair-sit, standing, ground-sit, and sleeping timelines.
- Resolves the selected actor's effective Penumbra collection and detects pose variants from the actor's resolved game paths.
- Applies selected entries through Brio's existing action timeline capability, so the resulting animation remains controllable from Brio.

## Motivation

Animation and pose mods commonly replace the game's base idle animations. Penumbra can identify the affected emote, but it does not expose which numbered idle variant is being replaced in a convenient form. Entering timeline IDs manually is also cumbersome.

This addresses the common-pose quick-access portion of #209:
https://github.com/Etheirys/Brio/issues/209

The actor-persistence request in that issue is intentionally outside the scope of this PR.

## Implementation notes

- Uses Penumbra's public IPC subscribers to resolve the actor collection, changed items, mod paths, game-object resources, and resolved replacement paths.
- Keeps a short-lived cache and invalidates the selector when detected mod actions change.
- Includes the commonly used timeline IDs listed in #209 for chair sitting, standing, ground sitting, and sleeping.
- Contains English UI text only; no Chinese resources or Brio-CN-specific behavior are included.

## Validation

- `dotnet build brio.slnx -c Debug`
- Result: 0 warnings, 0 errors