### PR TITLE
Add navigable world model previews

### DIFF
--- a/Brio/Services/PathMetadataService.cs
+++ b/Brio/Services/PathMetadataService.cs
@@ -92,6 +92,11 @@ public class PathMetadataService
     }
     private void Load(PathTarget target, ref byte[] data)
     {
+        // A new installation has no user path store yet. Treat the missing
+        // store as empty instead of reporting a corrupt-file error.
+        if(data.Length == 0)
+            return;
+
         try
         {
             var loaded = PathDatabase.Deserialize<PathStore>(data, PathStore.Magic);

--- a/Brio/UI/Controls/Editors/SpawnMenu.cs
+++ b/Brio/UI/Controls/Editors/SpawnMenu.cs
@@ -136,6 +136,12 @@ public class SpawnMenu
                     ImGui.CloseCurrentPopup();
                 }
 
+                if(ImBrio.IconButtonWithText(FontAwesomeIcon.Eye, "World Model Preview", buttonSize))
+                {
+                    UIManager.Instance.OpenModelPreviewBrowser();
+                    ImGui.CloseCurrentPopup();
+                }
+
                 if(ImBrio.IconButtonWithText(FontAwesomeIcon.Cubes, "Prop", buttonSize))
                 {
                     _worldObjectService.SpawnProp(new FFXIVClientStructs.FFXIV.Client.Graphics.Scene.WeaponCreateInfo

--- a/Brio/UI/Controls/Stateless/ImBrio.cs
+++ b/Brio/UI/Controls/Stateless/ImBrio.cs
@@ -68,19 +68,24 @@ public static partial class ImBrio
     [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
     public static bool IconButtonWithText(FontAwesomeIcon icon, string text, Vector2 size)
     {
-        var cursorPos = ImGui.GetCursorPos();
         bool clicked = ImGui.Button($"##{text}", size);
-
-        ImGui.SetCursorPos(cursorPos + new Vector2(5 * ImGuiHelpers.GlobalScale, ImGui.GetStyle().FramePadding.Y));
+        var buttonMin = ImGui.GetItemRectMin();
+        var buttonSize = ImGui.GetItemRectSize();
+        var drawList = ImGui.GetWindowDrawList();
+        var color = ImGui.GetColorU32(ImGuiCol.Text);
+        var padding = 5 * ImGuiHelpers.GlobalScale;
+        Vector2 iconSize;
 
         using(ImRaii.PushFont(UiBuilder.IconFont))
         {
-            ImGui.Text(icon.ToIconString());
+            var iconText = icon.ToIconString();
+            iconSize = ImGui.CalcTextSize(iconText);
+            drawList.AddText(buttonMin + new Vector2(padding, (buttonSize.Y - iconSize.Y) * 0.5f), color, iconText);
         }
 
-        ImGui.SameLine();
-        ImGui.SetCursorPosY(cursorPos.Y + ImGui.GetStyle().FramePadding.Y);
-        ImGui.Text(text);
+        var textSize = ImGui.CalcTextSize(text);
+        var textPosition = buttonMin + new Vector2(padding + iconSize.X + ImGui.GetStyle().ItemInnerSpacing.X, (buttonSize.Y - textSize.Y) * 0.5f);
+        drawList.AddText(textPosition, color, text);
 
         return clicked;
     }

--- a/Brio/UI/UIManager.cs
+++ b/Brio/UI/UIManager.cs
@@ -170,6 +170,7 @@ public class UIManager : IDisposable
         _windowSystem.AddWindow(_entitySectionWindow);
         _windowSystem.AddWindow(_timelineWindow);
         _windowSystem.AddWindow(_catalogWindow);
+        _windowSystem.AddWindow(_catalogWindow.ModelPreviewWindow);
 
         _gPoseService.OnGPoseStateChange += OnGPoseStateChange;
         _configurationService.OnConfigurationChanged += ApplySettings;
@@ -209,6 +210,11 @@ public class UIManager : IDisposable
     public void ToggleCatalogWindow()
     {
         _catalogWindow.IsOpen = !_catalogWindow.IsOpen;
+    }
+
+    public void OpenModelPreviewBrowser()
+    {
+        _catalogWindow.OpenModelPreviewBrowser();
     }
 
     public void ToggleProjectWindow()

--- a/Brio/UI/Windows/CatalogWindow.cs
+++ b/Brio/UI/Windows/CatalogWindow.cs
@@ -64,10 +64,13 @@ public class CatalogWindow : Window, IDisposable
     private List<string> _modelSubtypeOptions = [];
     private List<string> _modelAssetOptions = [];
     private CatalogDisplayMode _modelDisplayMode = CatalogDisplayMode.Compact;
-    private bool _modelLivePreviewEnabled;
+    private readonly CatalogModelPreviewWindow _modelPreviewWindow;
     private IWorldObject? _modelLivePreview;
     private string _modelLivePreviewPath = string.Empty;
+    private int _modelLivePreviewIndex = -1;
     private int _modelLivePreviewRequest;
+
+    public Window ModelPreviewWindow => _modelPreviewWindow;
 
     private List<GamePathInfo> _allVfx = [];
     private List<GamePathInfo> _filteredVfx = [];
@@ -93,6 +96,10 @@ public class CatalogWindow : Window, IDisposable
     private string _metaTerritoryInput = string.Empty;
     private string _metaLastExport = string.Empty;
     private IWorldObject? _metaPreview;
+    private bool _metaPreviewMode;
+    private int _metaPreviewRequest;
+    private int _metaJumpIndex = 1;
+    private bool _metaScrollToSelected;
 
     public CatalogWindow(GPoseService gPoseService, WorldObjectService worldObjectService, ConfigurationService configurationService, QuickAccessService quickAccess, PathMetadataService pathMetadata, IClientState clientState) : base($"{Brio.Name} - CATALOG###brio_furniture_catalog_window")
     {
@@ -104,6 +111,7 @@ public class CatalogWindow : Window, IDisposable
         _quickAccess = quickAccess;
         _pathMetadata = pathMetadata;
         _clientState = clientState;
+        _modelPreviewWindow = new CatalogModelPreviewWindow(this);
 
         this.AllowBackgroundBlur = false;
 
@@ -248,7 +256,7 @@ public class CatalogWindow : Window, IDisposable
         DrawMetadataToolbar();
 
         if(_metaKind == ObjectPathKind.Model)
-            DrawModelFilters();
+            DrawModelFilters(false);
         else
             DrawVfxFilters();
 
@@ -321,6 +329,20 @@ public class CatalogWindow : Window, IDisposable
             return;
         }
 
+        if(_metaScrollToSelected)
+        {
+            var selectedRow = rows.FindIndex(row => row.Header is null
+                && row.Index >= 0
+                && row.Index < items.Count
+                && items[row.Index].Path == _metaSelectedPath);
+            if(selectedRow >= 0)
+            {
+                var rowHeight = ImGui.GetTextLineHeightWithSpacing();
+                ImGui.SetScrollY(Math.Max(0, selectedRow * rowHeight - ImGui.GetWindowHeight() * 0.5f));
+            }
+            _metaScrollToSelected = false;
+        }
+
         var clipper = new ImGuiListClipperPtr(ImGuiNative.ImGuiListClipper());
         clipper.Begin(rows.Count);
         while(clipper.Step())
@@ -345,7 +367,7 @@ public class CatalogWindow : Window, IDisposable
 
                 string label = metadata is not null ? $"* {name}" : model.DisplayName;
                 if(ImGui.Selectable($"{label}###{key}", isSelected))
-                    LoadMetaEditing(model.Path, model);
+                    SelectMetadataItem(row.Index);
 
                 if(ImGui.IsItemHovered())
                     ImBrio.AttachToolTip($"{name}{ImBrio.TooltipSeparator}{model.Path}");
@@ -363,18 +385,32 @@ public class CatalogWindow : Window, IDisposable
             return;
         }
 
-        if(ImBrio.FontIconButton("meta_preview_spawn", FontAwesomeIcon.PlusCircle, "Spawn preview"))
+        var items = _metaKind == ObjectPathKind.Model ? _filteredModels : _filteredVfx;
+        var selectedIndex = items.FindIndex(item => item.Path == _metaSelectedPath);
+        var buttonHeight = ImGui.GetFrameHeight();
+
+        if(ImBrio.IconButtonWithText(FontAwesomeIcon.PlusCircle, "Spawn preview",
+            new Vector2(120 * ImGuiHelpers.GlobalScale, buttonHeight)))
             SpawnMetaPreview();
+
+        ImGui.SameLine();
+
+        using(ImRaii.Disabled(selectedIndex <= 0))
+            if(ImGui.Button("Previous", new Vector2(82 * ImGuiHelpers.GlobalScale, buttonHeight)))
+                SelectMetadataItem(selectedIndex - 1);
+
+        ImGui.SameLine();
+
+        using(ImRaii.Disabled(selectedIndex < 0 || selectedIndex >= items.Count - 1))
+            if(ImGui.Button("Next", new Vector2(82 * ImGuiHelpers.GlobalScale, buttonHeight)))
+                SelectMetadataItem(selectedIndex + 1);
 
         ImGui.SameLine();
 
         using(ImRaii.Disabled(_metaPreview is not { IsValid: true }))
         {
             if(ImBrio.FontIconButton("meta_preview_destroy", FontAwesomeIcon.Ban, "Destroy preview"))
-            {
-                _worldObjectService.Destroy(_metaPreview!);
-                _metaPreview = null;
-            }
+                StopMetaPreview();
         }
 
         ImGui.SameLine();
@@ -383,7 +419,24 @@ public class CatalogWindow : Window, IDisposable
         {
             _worldObjectService.DestroyAll();
             _metaPreview = null;
+            _metaPreviewMode = false;
+            _metaPreviewRequest++;
         }
+
+        ImGui.TextUnformatted("Index");
+        ImGui.SameLine();
+        ImGui.SetNextItemWidth(92 * ImGuiHelpers.GlobalScale);
+        ImGui.InputInt("###meta_jump_index", ref _metaJumpIndex, 0, 0);
+        var jumpConfirmed = ImBrio.IsItemConfirmed();
+        ImGui.SameLine();
+        using(ImRaii.Disabled(items.Count == 0))
+        {
+            var goTo = ImGui.Button("Go to");
+            if(items.Count > 0 && (goTo || jumpConfirmed))
+                SelectMetadataItem(Math.Clamp(_metaJumpIndex, 1, items.Count) - 1);
+        }
+
+        ImGui.TextDisabled($"Item {selectedIndex + 1} of {items.Count}");
 
         ImGui.Separator();
 
@@ -409,7 +462,8 @@ public class CatalogWindow : Window, IDisposable
 
         var pathExpansion = _metaSelectedInfo?.Expansion;
         ImGui.SameLine();
-        if(ImBrio.FontIconButton("###meta_expansion_from_path", FontAwesomeIcon.FileImport, $"Set from path ({pathExpansion})", !string.IsNullOrWhiteSpace(pathExpansion)))
+        if(ImBrio.FontIconButton("###meta_expansion_from_path", FontAwesomeIcon.FileImport,
+            $"Set from path ({pathExpansion})", !string.IsNullOrWhiteSpace(pathExpansion)))
             _metaEditing.Expansion = pathExpansion!.Trim();
 
         if(_metaKind == ObjectPathKind.VFX)
@@ -560,9 +614,50 @@ public class CatalogWindow : Window, IDisposable
         if(string.IsNullOrEmpty(_metaSelectedPath))
             return;
 
-        _metaPreview = _metaKind == ObjectPathKind.Model
-            ? await _worldObjectService.SpawnBgObjectAsync(_metaSelectedPath)
-            : await _worldObjectService.SpawnStaticVfxAsync(_metaSelectedPath);
+        _metaPreviewMode = true;
+        var request = ++_metaPreviewRequest;
+        var path = _metaSelectedPath;
+        var kind = _metaKind;
+
+        if(_metaPreview is { IsValid: true })
+            _worldObjectService.Destroy(_metaPreview);
+        _metaPreview = null;
+
+        IWorldObject? preview;
+        if(kind == ObjectPathKind.Model)
+            preview = await _worldObjectService.SpawnBgObjectAsync(path);
+        else
+            preview = await _worldObjectService.SpawnStaticVfxAsync(path);
+
+        if(request != _metaPreviewRequest || !_metaPreviewMode || path != _metaSelectedPath || kind != _metaKind)
+        {
+            if(preview is not null)
+                _worldObjectService.Destroy(preview);
+            return;
+        }
+
+        _metaPreview = preview;
+    }
+
+    private void StopMetaPreview()
+    {
+        _metaPreviewMode = false;
+        _metaPreviewRequest++;
+        if(_metaPreview is { IsValid: true })
+            _worldObjectService.Destroy(_metaPreview);
+        _metaPreview = null;
+    }
+
+    private void SelectMetadataItem(int index)
+    {
+        var items = _metaKind == ObjectPathKind.Model ? _filteredModels : _filteredVfx;
+        if(index < 0 || index >= items.Count)
+            return;
+
+        var item = items[index];
+        _metaJumpIndex = index + 1;
+        _metaScrollToSelected = true;
+        LoadMetaEditing(item.Path, item);
     }
 
     private void SetMetaTarget(PathTarget target)
@@ -574,9 +669,12 @@ public class CatalogWindow : Window, IDisposable
 
     private void LoadMetaEditing(string path, GamePathInfo? info = null)
     {
-        if(_metaPreview is { IsValid: true } && path != _metaSelectedPath)
+        var pathChanged = path != _metaSelectedPath;
+        if(pathChanged)
         {
-            _worldObjectService.Destroy(_metaPreview);
+            _metaPreviewRequest++;
+            if(_metaPreview is { IsValid: true })
+                _worldObjectService.Destroy(_metaPreview);
             _metaPreview = null;
         }
 
@@ -586,6 +684,9 @@ public class CatalogWindow : Window, IDisposable
             ? data.Clone()
             : new PathData { Path = path };
         _metaEditing.Path = path;
+
+        if(pathChanged && _metaPreviewMode)
+            SpawnMetaPreview();
     }
 
     private void ExportMetadata()
@@ -638,10 +739,10 @@ public class CatalogWindow : Window, IDisposable
             });
     }
 
-    private bool DrawSearchAndViewMode(ref string searchText, ref CatalogDisplayMode mode, string id)
+    private bool DrawSearchAndViewMode(ref string searchText, ref CatalogDisplayMode mode, string id, float extraReservedWidth = 0)
     {
         bool applay = false;
-        ImGui.SetNextItemWidth((ImBrio.GetRemainingWidth() - 125) * ImGuiHelpers.GlobalScale);
+        ImGui.SetNextItemWidth((ImBrio.GetRemainingWidth() - 125 - extraReservedWidth) * ImGuiHelpers.GlobalScale);
         if(ImGui.InputTextWithHint("###vfx_search", "Search...", ref searchText, 256))
             applay = true;
 
@@ -671,25 +772,18 @@ public class CatalogWindow : Window, IDisposable
         ImGui.SameLine();
         ImGui.TextUnformatted($"{_filteredFurnishings.Count:N0} of {_allFurnishings.Count:N0} items");
     }
-    private void DrawModelFilters()
+    private void DrawModelFilters(bool showPreviewButton = true)
     {
-        if(DrawSearchAndViewMode(ref _modelSearch, ref _modelDisplayMode, "model_view"))
+        const float previewButtonWidth = 145;
+        if(DrawSearchAndViewMode(ref _modelSearch, ref _modelDisplayMode, "model_view", showPreviewButton ? previewButtonWidth : 0))
             ApplyModelFilter();
 
-        ImGui.SameLine();
-        if(ImBrio.ToggelFontIconButton("model_live_preview", FontAwesomeIcon.Eye, new Vector2(24, 5), _modelLivePreviewEnabled,
-            tooltip: "Live Preview (single-click previews, double-click spawns)"))
+        if(showPreviewButton)
         {
-            _modelLivePreviewEnabled = !_modelLivePreviewEnabled;
-            if(!_modelLivePreviewEnabled)
-                ClearModelLivePreview();
-        }
-
-        ImGui.SameLine();
-        using(ImRaii.Disabled(_modelLivePreview is not { IsValid: true }))
-        {
-            if(ImBrio.FontIconButton("model_live_preview_clear", FontAwesomeIcon.Ban, "Clear Live Preview"))
-                ClearModelLivePreview();
+            ImGui.SameLine();
+            if(ImBrio.IconButtonWithText(FontAwesomeIcon.Eye, "Open Model Preview",
+                new Vector2(previewButtonWidth * ImGuiHelpers.GlobalScale, ImGui.GetFrameHeight())))
+                OpenModelPreview();
         }
 
         float third = (ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X * 2) / 3f;
@@ -960,22 +1054,109 @@ public class CatalogWindow : Window, IDisposable
 
     private void HandleCatalogSelection(ObjectPathKind kind, string path, string name, uint iconId, bool doubleClicked)
     {
-        if(_modelLivePreviewEnabled && kind == ObjectPathKind.Model)
+        if(_modelPreviewWindow.IsOpen && kind == ObjectPathKind.Model)
         {
-            if(doubleClicked)
-            {
-                ClearModelLivePreview();
-                Spawn(kind, path, name, iconId);
-            }
-            else
-            {
-                PreviewModel(path);
-            }
-
+            SelectModelPreview(path);
             return;
         }
 
         Spawn(kind, path, name, iconId);
+    }
+
+    private void OpenModelPreview()
+    {
+        _modelPreviewWindow.IsOpen = true;
+        if(_filteredModels.Count == 0)
+            return;
+
+        var currentIndex = _filteredModels.FindIndex(model => model.Path == _modelLivePreviewPath);
+        SelectModelPreview(currentIndex >= 0 ? currentIndex : 0);
+    }
+
+    public void OpenModelPreviewBrowser()
+    {
+        IsOpen = true;
+        categorySelection = 4;
+        _metaKind = ObjectPathKind.Model;
+    }
+
+    private void SelectModelPreview(string path)
+    {
+        var index = _filteredModels.FindIndex(model => model.Path == path);
+        if(index >= 0)
+            SelectModelPreview(index);
+    }
+
+    private void SelectModelPreview(int index)
+    {
+        if(index < 0 || index >= _filteredModels.Count)
+            return;
+
+        _modelLivePreviewIndex = index;
+        PreviewModel(_filteredModels[index].Path);
+    }
+
+    private void NavigateModelPreview(int direction)
+    {
+        if(_filteredModels.Count == 0)
+            return;
+
+        SelectModelPreview(Math.Clamp(_modelLivePreviewIndex + direction, 0, _filteredModels.Count - 1));
+    }
+
+    private void ApplyModelPreview()
+    {
+        if(_modelLivePreview is not { IsValid: true }
+            || _modelLivePreviewIndex < 0
+            || _modelLivePreviewIndex >= _filteredModels.Count)
+            return;
+
+        var model = _filteredModels[_modelLivePreviewIndex];
+        var metadata = _pathMetadata.PathDatabase.GetPathDataByPath(model.Path);
+        var name = metadata is not null ? $"{metadata.Name} ({model.DisplayName})" : model.DisplayName;
+        _quickAccess.PushRecent(MakeEntry(ObjectPathKind.Model, model.Path, name, 0));
+
+        _modelLivePreviewRequest++;
+        _modelLivePreview = null;
+        _modelLivePreviewPath = string.Empty;
+        _modelLivePreviewIndex = -1;
+        _modelPreviewWindow.IsOpen = false;
+    }
+
+    private void DrawModelPreviewWindow()
+    {
+        ImBrio.BlurWindow();
+
+        if(_filteredModels.Count == 0 || _modelLivePreviewIndex < 0 || _modelLivePreviewIndex >= _filteredModels.Count)
+        {
+            ImGui.TextWrapped("No models match the current filter.");
+            return;
+        }
+
+        var model = _filteredModels[_modelLivePreviewIndex];
+        var metadata = _pathMetadata.PathDatabase.GetPathDataByPath(model.Path);
+        var name = metadata is not null ? $"{metadata.Name} ({model.DisplayName})" : model.DisplayName;
+
+        ImGui.TextWrapped(name);
+        ImGui.TextDisabled($"Model {_modelLivePreviewIndex + 1} of {_filteredModels.Count}");
+        ImGui.Separator();
+        ImGui.TextWrapped(model.Path);
+        ImBrio.VerticalPadding(4);
+
+        var spacing = ImGui.GetStyle().ItemSpacing.X;
+        var halfWidth = (ImGui.GetContentRegionAvail().X - spacing) / 2f;
+        using(ImRaii.Disabled(_modelLivePreviewIndex <= 0))
+            if(ImGui.Button("Previous", new Vector2(halfWidth, 0)))
+                NavigateModelPreview(-1);
+
+        ImGui.SameLine();
+        using(ImRaii.Disabled(_modelLivePreviewIndex >= _filteredModels.Count - 1))
+            if(ImGui.Button("Next", new Vector2(halfWidth, 0)))
+                NavigateModelPreview(1);
+
+        using(ImRaii.Disabled(_modelLivePreview is not { IsValid: true }))
+            if(ImGui.Button("Apply This Model", new Vector2(-1, 0)))
+                ApplyModelPreview();
     }
 
     private async void PreviewModel(string path)
@@ -989,7 +1170,7 @@ public class CatalogWindow : Window, IDisposable
         try
         {
             var preview = await _worldObjectService.SpawnBgObjectAsync(path);
-            if(request != _modelLivePreviewRequest || !_modelLivePreviewEnabled)
+            if(request != _modelLivePreviewRequest || !_modelPreviewWindow.IsOpen)
             {
                 if(preview is not null)
                     _worldObjectService.Destroy(preview);
@@ -1088,6 +1269,20 @@ public class CatalogWindow : Window, IDisposable
 
         _filteredModels = [.. items];
         _modelRows = BuildRows(_filteredModels, m => m.AssetType);
+
+        if(_modelPreviewWindow.IsOpen)
+        {
+            var currentIndex = _filteredModels.FindIndex(model => model.Path == _modelLivePreviewPath);
+            if(currentIndex >= 0)
+                _modelLivePreviewIndex = currentIndex;
+            else if(_filteredModels.Count > 0)
+                SelectModelPreview(0);
+            else
+            {
+                ClearModelLivePreview();
+                _modelLivePreviewIndex = -1;
+            }
+        }
     }
     private void ApplyVfxFilter()
     {
@@ -1213,21 +1408,52 @@ public class CatalogWindow : Window, IDisposable
     {
         if(!newState)
         {
+            _modelPreviewWindow.IsOpen = false;
             ClearModelLivePreview();
+            _modelLivePreviewIndex = -1;
             IsOpen = false;
         }
     }
 
     public override void OnClose()
     {
+        _modelPreviewWindow.IsOpen = false;
         ClearModelLivePreview();
+        _modelLivePreviewIndex = -1;
         base.OnClose();
     }
 
     public void Dispose()
     {
+        _modelPreviewWindow.IsOpen = false;
         ClearModelLivePreview();
         _gPoseService.OnGPoseStateChange -= OnGPoseStateChange;
+    }
+
+    private sealed class CatalogModelPreviewWindow : Window
+    {
+        private readonly CatalogWindow _owner;
+
+        public CatalogModelPreviewWindow(CatalogWindow owner)
+            : base("Model Preview###brio_catalog_model_preview", ImGuiWindowFlags.NoCollapse)
+        {
+            _owner = owner;
+            SizeConstraints = new WindowSizeConstraints
+            {
+                MinimumSize = new Vector2(320, 170),
+                MaximumSize = new Vector2(520, 320),
+            };
+        }
+
+        public override void Draw()
+            => _owner.DrawModelPreviewWindow();
+
+        public override void OnClose()
+        {
+            _owner.ClearModelLivePreview();
+            _owner._modelLivePreviewIndex = -1;
+            base.OnClose();
+        }
     }
 }
 

--- a/Brio/UI/Windows/CatalogWindow.cs
+++ b/Brio/UI/Windows/CatalogWindow.cs
@@ -64,6 +64,10 @@ public class CatalogWindow : Window, IDisposable
     private List<string> _modelSubtypeOptions = [];
     private List<string> _modelAssetOptions = [];
     private CatalogDisplayMode _modelDisplayMode = CatalogDisplayMode.Compact;
+    private bool _modelLivePreviewEnabled;
+    private IWorldObject? _modelLivePreview;
+    private string _modelLivePreviewPath = string.Empty;
+    private int _modelLivePreviewRequest;
 
     private List<GamePathInfo> _allVfx = [];
     private List<GamePathInfo> _filteredVfx = [];
@@ -672,6 +676,22 @@ public class CatalogWindow : Window, IDisposable
         if(DrawSearchAndViewMode(ref _modelSearch, ref _modelDisplayMode, "model_view"))
             ApplyModelFilter();
 
+        ImGui.SameLine();
+        if(ImBrio.ToggelFontIconButton("model_live_preview", FontAwesomeIcon.Eye, new Vector2(24, 5), _modelLivePreviewEnabled,
+            tooltip: "Live Preview (single-click previews, double-click spawns)"))
+        {
+            _modelLivePreviewEnabled = !_modelLivePreviewEnabled;
+            if(!_modelLivePreviewEnabled)
+                ClearModelLivePreview();
+        }
+
+        ImGui.SameLine();
+        using(ImRaii.Disabled(_modelLivePreview is not { IsValid: true }))
+        {
+            if(ImBrio.FontIconButton("model_live_preview_clear", FontAwesomeIcon.Ban, "Clear Live Preview"))
+                ClearModelLivePreview();
+        }
+
         float third = (ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X * 2) / 3f;
         if(ImBrio.MultiComboBox("###model_exp", _modelExpansionOptions, ref _selectedModelExpansions, third, "All Expansions"))
             ApplyModelFilter();
@@ -743,7 +763,7 @@ public class CatalogWindow : Window, IDisposable
                 ImGui.SameLine(0, 4 * ImGuiHelpers.GlobalScale);
 
                 if(ImGui.Selectable($"{name}###{key}"))
-                    Spawn(kind, model.Path, name, 0);
+                    HandleCatalogSelection(kind, model.Path, name, 0, ImGui.IsMouseDoubleClicked(ImGuiMouseButton.Left));
 
                 if(ImGui.IsItemHovered())
                     ImBrio.AttachToolTip(metadata is not null ? $"{metadata.Name}{ImBrio.TooltipSeparator}{model.Path}" : $"{model.DisplayName}{ImBrio.TooltipSeparator}{model.Path}");
@@ -888,9 +908,11 @@ public class CatalogWindow : Window, IDisposable
     private void DrawGameIcon(string key, uint iconId, string name, string path, ObjectPathKind kind, float iconSize)
     {
         bool clicked;
+        bool doubleClicked;
         using(ImRaii.Group())
         {
             clicked = ImBrio.BorderedGameIcon(key, iconId, "Images.UnknownIcon.png", size: new Vector2(iconSize));
+            doubleClicked = clicked && ImGui.IsMouseDoubleClicked(ImGuiMouseButton.Left);
 
             float tileW = ImGui.GetItemRectSize().X;
             float starW = ImGui.GetTextLineHeight();
@@ -906,7 +928,7 @@ public class CatalogWindow : Window, IDisposable
             ImBrio.AttachToolTip($"{name}{ImBrio.TooltipSeparator}{path}");
 
         if(clicked)
-            Spawn(kind, path, name, iconId);
+            HandleCatalogSelection(kind, path, name, iconId, doubleClicked);
 
         IconRightClick($"###rightclick_{key}", kind, path, name, iconId);
     }
@@ -933,6 +955,72 @@ public class CatalogWindow : Window, IDisposable
 
     private void ToggleFav(ObjectPathKind kind, string path, string name, uint iconId)
         => _quickAccess.ToggleFavorite(MakeEntry(kind, path, name, iconId));
+
+    //
+
+    private void HandleCatalogSelection(ObjectPathKind kind, string path, string name, uint iconId, bool doubleClicked)
+    {
+        if(_modelLivePreviewEnabled && kind == ObjectPathKind.Model)
+        {
+            if(doubleClicked)
+            {
+                ClearModelLivePreview();
+                Spawn(kind, path, name, iconId);
+            }
+            else
+            {
+                PreviewModel(path);
+            }
+
+            return;
+        }
+
+        Spawn(kind, path, name, iconId);
+    }
+
+    private async void PreviewModel(string path)
+    {
+        if(_modelLivePreviewPath == path && _modelLivePreview is { IsValid: true })
+            return;
+
+        var request = ++_modelLivePreviewRequest;
+        ClearModelLivePreview(invalidatePendingRequest: false);
+
+        try
+        {
+            var preview = await _worldObjectService.SpawnBgObjectAsync(path);
+            if(request != _modelLivePreviewRequest || !_modelLivePreviewEnabled)
+            {
+                if(preview is not null)
+                    _worldObjectService.Destroy(preview);
+                return;
+            }
+
+            _modelLivePreview = preview;
+            _modelLivePreviewPath = preview is null ? string.Empty : path;
+        }
+        catch(Exception ex)
+        {
+            Brio.Log.Error(ex, $"Failed to create a live model preview for {path}");
+            if(request == _modelLivePreviewRequest)
+            {
+                _modelLivePreview = null;
+                _modelLivePreviewPath = string.Empty;
+            }
+        }
+    }
+
+    private void ClearModelLivePreview(bool invalidatePendingRequest = true)
+    {
+        if(invalidatePendingRequest)
+            _modelLivePreviewRequest++;
+
+        if(_modelLivePreview is { IsValid: true })
+            _worldObjectService.Destroy(_modelLivePreview);
+
+        _modelLivePreview = null;
+        _modelLivePreviewPath = string.Empty;
+    }
 
     //
 
@@ -1124,11 +1212,21 @@ public class CatalogWindow : Window, IDisposable
     private void OnGPoseStateChange(bool newState)
     {
         if(!newState)
+        {
+            ClearModelLivePreview();
             IsOpen = false;
+        }
+    }
+
+    public override void OnClose()
+    {
+        ClearModelLivePreview();
+        base.OnClose();
     }
 
     public void Dispose()
     {
+        ClearModelLivePreview();
         _gPoseService.OnGPoseStateChange -= OnGPoseStateChange;
     }
 }


### PR DESCRIPTION
## Summary

- Adds a reusable world-model preview workflow to the catalog.
- Adds **Previous** and **Next** navigation plus direct numeric index jumps.
- Synchronizes metadata selection, list scrolling, and the currently spawned preview entity.
- Adds a focused model-preview window with navigation and an explicit **Apply This Model** action.
- Adds direct access to world-model preview browsing from Brio's spawn menu.

## Motivation

World-object entries are often identified primarily by internal paths and codes. Spawning each entry permanently just to discover what it represents is slow and leaves extra entities to clean up. A persistent preview entity makes browsing the catalog much faster: selecting or navigating to another entry replaces the existing preview in place.

## Implementation notes

- Reuses a single Brio-managed preview entity instead of accumulating spawned objects.
- Cancels or disposes stale asynchronous preview results when the selection changes quickly.
- Cleans up previews when the preview window or catalog closes and when GPose ends.
- Keeps the metadata list selection and scroll position synchronized with Previous/Next and numeric navigation.
- Treats a missing user metadata store as empty on a new installation instead of reporting it as a corrupt file.
- Fixes `IconButtonWithText` layout so subsequent same-line controls use the full button bounds.
- Contains English UI text only; no Chinese resources or Brio-CN-specific behavior are included.

## Validation

- `dotnet build brio.slnx -c Debug`
- Result: 0 warnings, 0 errors