### PR TITLE
Add "Open Camera Window" menu item to CameraLifetimeWidget

### DIFF
--- a/Brio/Capabilities/Camera/CameraLifetimeCapability.cs
+++ b/Brio/Capabilities/Camera/CameraLifetimeCapability.cs
@@ -4,21 +4,28 @@ using Brio.Game.Camera;
 using Brio.Game.GPose;
 using Brio.Game.World;
 using Brio.UI.Widgets.Camera;
+using Brio.UI.Windows.Specialized;
 
 namespace Brio.Capabilities.Camera;
 
 public class CameraLifetimeCapability : CameraCapability
 {
     private readonly VirtualCameraManager _virtualCameraManager;
+    private readonly CameraWindow _cameraWindow;
 
     public VirtualCameraManager VirtualCameraManager => _virtualCameraManager;
 
-    public CameraLifetimeCapability(CameraEntity parent, GPoseService gPoseService, VirtualCameraManager virtualCameraManager, ActorSpawnService actorSpawnService, LightingService lightingService) : base(parent, gPoseService)
+    public CameraLifetimeCapability(CameraEntity parent, GPoseService gPoseService, VirtualCameraManager virtualCameraManager, ActorSpawnService actorSpawnService, LightingService lightingService, CameraWindow cameraWindow) : base(parent, gPoseService)
     {
         _virtualCameraManager = virtualCameraManager;
+        _cameraWindow = cameraWindow;
 
         Widget = new CameraLifetimeWidget(this);
     }
 
     public bool CanDestroy => CameraEntity.CameraID != 0;
+
+    public void OpenCameraWindow() {
+        _cameraWindow.IsOpen = true;
+    }
 }

--- a/Brio/Capabilities/Camera/CameraLifetimeCapability.cs
+++ b/Brio/Capabilities/Camera/CameraLifetimeCapability.cs
@@ -25,7 +25,8 @@ public class CameraLifetimeCapability : CameraCapability
 
     public bool CanDestroy => CameraEntity.CameraID != 0;
 
-    public void OpenCameraWindow() {
+    public void OpenCameraWindow()
+    {
         _cameraWindow.IsOpen = true;
     }
 }

--- a/Brio/Game/Actor/ActorAppearanceService.cs
+++ b/Brio/Game/Actor/ActorAppearanceService.cs
@@ -185,7 +185,7 @@ public class ActorAppearanceService : IDisposable
                                     Buffer.MemoryCopy(existingAppearance.Equipment.Data, ptr + 32, 80, 80);
                                 }
 
-                                var didUpdate = human->Human.UpdateDrawData((DrawData*)ptr, false);
+                                var didUpdate = human->Human.UpdateDrawData((Human.DrawData*)ptr, false);
                                 needsRedraw |= !didUpdate;
                             }
                         }

--- a/Brio/UI/Widgets/Camera/CameraLifetimeWidet.cs
+++ b/Brio/UI/Widgets/Camera/CameraLifetimeWidet.cs
@@ -30,10 +30,6 @@ public class CameraLifetimeWidget(CameraLifetimeCapability capability) : Widget<
                 Capability.VirtualCameraManager.SelectCamera(Capability.VirtualCamera);
             }
 
-            if(ImBrio.FontIconButton("CameraLifetime_editor", FontAwesomeIcon.Edit, "Open Camera Editor")) {
-                Capability.OpenCameraWindow();
-            }
-
             ImBrio.VerticalSeparator(24, 1);
 
             using(ImRaii.Disabled(Capability.CameraEntity.CameraID == 0))

--- a/Brio/UI/Widgets/Camera/CameraLifetimeWidet.cs
+++ b/Brio/UI/Widgets/Camera/CameraLifetimeWidet.cs
@@ -30,6 +30,10 @@ public class CameraLifetimeWidget(CameraLifetimeCapability capability) : Widget<
                 Capability.VirtualCameraManager.SelectCamera(Capability.VirtualCamera);
             }
 
+            if(ImBrio.FontIconButton("CameraLifetime_editor", FontAwesomeIcon.Edit, "Open Camera Editor")) {
+                Capability.OpenCameraWindow();
+            }
+
             ImBrio.VerticalSeparator(24, 1);
 
             using(ImRaii.Disabled(Capability.CameraEntity.CameraID == 0))
@@ -87,6 +91,10 @@ public class CameraLifetimeWidget(CameraLifetimeCapability capability) : Widget<
         if(ImGui.MenuItem($"{lockLabel}###CameraLifetime_lock"))
         {
             Capability.Entity.IsLocked = !Capability.Entity.IsLocked;
+        }
+
+        if(ImGui.MenuItem("Open Camera Editor###CameraLifetime_editor_open")) {
+            Capability.OpenCameraWindow();
         }
 
         if(Capability.CanDestroy)


### PR DESCRIPTION
## Summary

- Add "Open Camera Window" menu item to CameraLifetimeWidget

## Motivation

When I right click a light entity, there's an option to open the light editor. I would really like an option to do the same with cameras instead of having to remember to right click the Entities item.

## Validation

- `dotnet build brio.slnx -c Debug`
- Result: 0 errors

<img width="346" height="334" alt="image" src="https://github.com/user-attachments/assets/de895238-9631-4a8d-9a0c-78a8a52c657c" />
